### PR TITLE
await completion of async methods (WARN Registration for queue " + queueName + " has chhas changed to " + consumer)

### DIFF
--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="true"
+                     xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
We see a lot of these warnings in our project

                } else {
                    // Somehow registration changed. Let's renotify.
                    log.warn("Registration for queue " + queueName + " has chhas changed to " + consumer);

The goal of this PR is to get rid of them. We now wait for async methods to complete prior to continue execution where not the case yet.