### PR TITLE
use apache base64 decoder

### DIFF
--- a/src/main/java/org/swisspush/redisques/util/HttpServerRequestUtil.java
+++ b/src/main/java/org/swisspush/redisques/util/HttpServerRequestUtil.java
@@ -4,6 +4,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,7 @@ public class HttpServerRequestUtil {
     private static final String CONTENT_LENGTH = "Content-Length";
     private static final String CONTENT_TYPE = "content-type";
     private static final String APPLICATION_JSON = "application/json";
+    private static final Base64 apacheDecoder = new Base64();
 
     /**
      * Evaluates whether the provided request contains the provided url parameter and the value is either an empty
@@ -134,9 +136,9 @@ public class HttpServerRequestUtil {
             String value = header.getString(1);
             if (key.equalsIgnoreCase(CONTENT_TYPE) && (value.contains("text/") || value.contains(APPLICATION_JSON))) {
                 try {
-                    object.put(PAYLOAD_OBJECT, new JsonObject(new String(object.getBinary(PAYLOAD), StandardCharsets.UTF_8)));
+                    object.put(PAYLOAD_OBJECT, new JsonObject(new String(apacheDecoder.decode(object.getString(PAYLOAD)), StandardCharsets.UTF_8)));
                 } catch (DecodeException e) {
-                    object.put(PAYLOAD_STRING, new String(object.getBinary(PAYLOAD), StandardCharsets.UTF_8));
+                    object.put(PAYLOAD_STRING, new String(apacheDecoder.decode(object.getString(PAYLOAD)), StandardCharsets.UTF_8));
                 }
                 object.remove(PAYLOAD);
                 break;

--- a/src/test/java/org/swisspush/redisques/util/HttpServerRequestUtilTest.java
+++ b/src/test/java/org/swisspush/redisques/util/HttpServerRequestUtilTest.java
@@ -81,4 +81,39 @@ public class HttpServerRequestUtilTest {
         context.assertTrue(result.isErr());
         context.assertEquals("no array called 'locks' found", result.getErr());
     }
+
+    @Test
+    public void testBase64Decoder(TestContext context){
+        String testDataUrlEncoded =  "{\n" +
+                "  \"headers\": [\n" +
+                "    [\n" +
+                "      \"Content-Type\",\n" +
+                "      \"application/json\"\n" +
+                "    ],\n" +
+                "    [\n" +
+                "      \"Accept-Charset\",\n" +
+                "      \"utf-8, iso-8859-1, utf-16, *;q=0.7\"\n" +
+                "    ]\n" +
+                "  ],\n" +
+                "  \"queueTimestamp\": 1477983671291,\n" +
+                "   \"payload\": \"5rWL6K-V\"\n" +
+                "}";
+        String testDataEncoded =  "{\n" +
+                "  \"headers\": [\n" +
+                "    [\n" +
+                "      \"Content-Type\",\n" +
+                "      \"application/json\"\n" +
+                "    ],\n" +
+                "    [\n" +
+                "      \"Accept-Charset\",\n" +
+                "      \"utf-8, iso-8859-1, utf-16, *;q=0.7\"\n" +
+                "    ]\n" +
+                "  ],\n" +
+                "  \"queueTimestamp\": 1477983671291,\n" +
+                "   \"payload\": \"5rWL6K+V\"\n" +
+                "}";
+        String decodedUrlPayload = HttpServerRequestUtil.decode(testDataUrlEncoded);
+        String decodedPayload = HttpServerRequestUtil.decode(testDataEncoded);
+        context.assertEquals(decodedUrlPayload, decodedPayload);
+    }
 }


### PR DESCRIPTION
This is related to https://github.com/eclipse-vertx/vert.x/pull/3123

With this PR we support two payloads encoding formats:

- the new format (base64url)
- the old format (plain base64)

This should allow us to migrate to the "new format"

