### PR TITLE
Added dequeue statistics

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -598,7 +598,7 @@ public class RedisQues extends AbstractVerticle {
                     }
                     if (answer.result() != null) {
                         dequeueStatistic.computeIfAbsent(queueName, s -> new DequeueStatistic());
-                        dequeueStatistic.get(queueName).lastDequeueAttemptTimestamp = new Date().getTime();
+                        dequeueStatistic.get(queueName).lastDequeueAttemptTimestamp = System.currentTimeMillis();
                         processMessageWithTimeout(queueName, answer.result().toString(), success -> {
 
                             // update the queue failure count and get a retry interval
@@ -685,7 +685,7 @@ public class RedisQues extends AbstractVerticle {
             log.trace("RedsQues reschedule after failure for queue: {}", queueName);
         }
         long retryDelayInMills = retryInSeconds * 1000L;
-        dequeueStatistic.get(queueName).nextDequeueDueTimestamp = new Date().getTime() + retryDelayInMills;
+        dequeueStatistic.get(queueName).nextDequeueDueTimestamp = System.currentTimeMillis() + retryDelayInMills;
         vertx.setTimer(retryDelayInMills, timerId -> {
             if (log.isDebugEnabled()) {
                 log.debug("RedisQues re-notify the consumer of queue '{}' at {}", queueName, new Date(System.currentTimeMillis()));
@@ -723,7 +723,7 @@ public class RedisQues extends AbstractVerticle {
                 boolean success;
                 if (reply.succeeded()) {
                     success = OK.equals(reply.result().body().getString(STATUS));
-                    dequeueStatistic.get(queue).lastDequeueSuccessTimestamp = new Date().getTime();
+                    dequeueStatistic.get(queue).lastDequeueSuccessTimestamp = System.currentTimeMillis();
                     dequeueStatistic.get(queue).nextDequeueDueTimestamp = null;
                 } else {
                     log.info("RedisQues QUEUE_ERROR: Consumer failed {} queue: {} ({})", uid, queue, reply.cause().getMessage());

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -844,7 +844,6 @@ public class RedisQues extends AbstractVerticle {
                                 });
                             } else {
                                 // Ensure we clean the old queues also in the case of empty queue.
-                                log.trace("RedisQues remove old queue: {}", queueName);
                                 if (log.isTraceEnabled()) {
                                     log.trace("RedisQues remove old queue: {}", queueName);
                                 }

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -566,16 +566,11 @@ public class RedisQues extends AbstractVerticle {
                         log.error("Failed to peek queue '{}'", queueName, answer.cause());
                         // We should return here. See: "https://softwareengineering.stackexchange.com/a/190535"
                     }
-                    if (log.isTraceEnabled()) {
-                        log.trace("RedisQues read queue lindex result: {}", answer.result());
-                    }
-                    if (answer.result() != null) {
-                        dequeueStatistic.computeIfAbsent(queueName, s -> new DequeueStatistic());
-                        dequeueStatistic.get(queueName).lastDequeueAttemptTimestamp = System.currentTimeMillis();
-                        processMessageWithTimeout(queueName, answer.result().toString(), success -> {
                     Response response = answer.result();
                     log.trace("RedisQues read queue lindex result: {}", response);
                     if (response != null) {
+                        dequeueStatistic.computeIfAbsent(queueName, s -> new DequeueStatistic());
+                        dequeueStatistic.get(queueName).lastDequeueAttemptTimestamp = System.currentTimeMillis();
                         processMessageWithTimeout(queueName, response.toString(), success -> {
 
                             // update the queue failure count and get a retry interval
@@ -659,12 +654,8 @@ public class RedisQues extends AbstractVerticle {
         log.trace("RedsQues reschedule after failure for queue: {}", queueName);
 
         vertx.setTimer(retryInSeconds * 1000L, timerId -> {
-        if (log.isTraceEnabled()) {
-            log.trace("RedsQues reschedule after failure for queue: {}", queueName);
-        }
-        long retryDelayInMills = retryInSeconds * 1000L;
-        dequeueStatistic.get(queueName).nextDequeueDueTimestamp = System.currentTimeMillis() + retryDelayInMills;
-        vertx.setTimer(retryDelayInMills, timerId -> {
+            long retryDelayInMills = retryInSeconds * 1000L;
+            dequeueStatistic.get(queueName).nextDequeueDueTimestamp = System.currentTimeMillis() + retryDelayInMills;
             if (log.isDebugEnabled()) {
                 log.debug("RedisQues re-notify the consumer of queue '{}' at {}", queueName, new Date(System.currentTimeMillis()));
             }

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -563,7 +563,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                         queuesList = limitJsonQueueArray(queuesList, limit);
                     }
 
-                    // this function always Success
+                    // this function always succeeds, no need to handle the error case
                     fillStatisticToQueuesList(queuesList).onSuccess(updatedQueuesList -> {
                         JsonObject resultObject = new JsonObject();
                         resultObject.put(QUEUES, updatedQueuesList);
@@ -586,8 +586,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private Future<List<JsonObject>> fillStatisticToQueuesList(List<JsonObject> queuesList) {
         Promise<List<JsonObject>> promise = Promise.promise();
         List<String> queueNameList = new ArrayList<>();
-        for (JsonObject jsonObject : queuesList)
-        {
+        for (JsonObject jsonObject : queuesList) {
             queueNameList.add(jsonObject.getString(MONITOR_QUEUE_NAME));
         }
 

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -512,9 +512,9 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                     if (limit > 0) {
                         queuesList = limitJsonQueueArray(queuesList, limit);
                     }
-                    Map<String, RedisQues.DequeueStatistic> processTimeList = redisQues.getDequeueStatistic();
-                    if (processTimeList.size() > 0){
-                        fillTheProcessTimeToQueuesList(queuesList, processTimeList);
+                    Map<String, RedisQues.DequeueStatistic> dequeueProcessStatistic = redisQues.getDequeueStatistic();
+                    if (dequeueProcessStatistic.size() > 0) {
+                        fillStatisticToQueuesList(queuesList, dequeueProcessStatistic);
                     }
                     JsonObject resultObject = new JsonObject();
                     resultObject.put(QUEUES, queuesList);
@@ -533,18 +533,22 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         });
     }
 
-    private void fillTheProcessTimeToQueuesList(List<JsonObject> queuesList, Map<String, RedisQues.DequeueStatistic> processTimeList) {
+    private void fillStatisticToQueuesList(List<JsonObject> queuesList, Map<String, RedisQues.DequeueStatistic> dequeueProcessStatistic) {
         queuesList.forEach(entries -> {
             String queueName = entries.getString(MONITOR_QUEUE_NAME);
             entries.put(MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT, "");
             entries.put(MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS, "");
-            if (processTimeList.containsKey(queueName)) {
-                RedisQues.DequeueStatistic dequeueStatistic = processTimeList.get(queueName);
+            entries.put(MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS, "");
+            if (dequeueProcessStatistic.containsKey(queueName)) {
+                RedisQues.DequeueStatistic dequeueStatistic = dequeueProcessStatistic.get(queueName);
                 if (dequeueStatistic.lastDequeueAttemptTimestamp != null) {
                     entries.put(MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueAttemptTimestamp)));
                 }
-                if (dequeueStatistic.lastDequeueAttemptTimestamp != null) {
+                if (dequeueStatistic.lastDequeueSuccessTimestamp != null) {
                     entries.put(MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueSuccessTimestamp)));
+                }
+                if (dequeueStatistic.nextDequeueDueTimestamp != null) {
+                    entries.put(MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS, dequeueStatistic.nextDequeueDueTimestamp.toString());
                 }
             }
         });

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -513,9 +513,8 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                         queuesList = limitJsonQueueArray(queuesList, limit);
                     }
                     Map<String, RedisQues.DequeueStatistic> dequeueProcessStatistic = redisQues.getDequeueStatistic();
-                    if (dequeueProcessStatistic.size() > 0) {
-                        fillStatisticToQueuesList(queuesList, dequeueProcessStatistic);
-                    }
+                    fillStatisticToQueuesList(queuesList, dequeueProcessStatistic);
+
                     JsonObject resultObject = new JsonObject();
                     resultObject.put(QUEUES, queuesList);
                     jsonResponse(ctx.response(), resultObject);
@@ -548,7 +547,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                     entries.put(MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueSuccessTimestamp)));
                 }
                 if (dequeueStatistic.nextDequeueDueTimestamp != null) {
-                    entries.put(MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS, dequeueStatistic.nextDequeueDueTimestamp.toString());
+                    entries.put(MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS, DATE_FORMAT.format(new Date(dequeueStatistic.nextDequeueDueTimestamp)));
                 }
             }
         });

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -2,7 +2,9 @@ package org.swisspush.redisques.handler;
 
 import io.netty.util.internal.StringUtil;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
@@ -10,6 +12,7 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
@@ -18,7 +21,8 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BasicAuthHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.swisspush.redisques.RedisQues;
+import org.swisspush.redisques.util.DequeueStatistic;
+import org.swisspush.redisques.util.QueueStatisticsCollector;
 import org.swisspush.redisques.util.RedisquesAPI;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import org.swisspush.redisques.util.Result;
@@ -26,14 +30,60 @@ import org.swisspush.redisques.util.StatusCode;
 
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.swisspush.redisques.util.HttpServerRequestUtil.*;
-import static org.swisspush.redisques.util.RedisquesAPI.*;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.decode;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.encodePayload;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.evaluateUrlParameterToBeEmptyOrTrue;
+import static org.swisspush.redisques.util.HttpServerRequestUtil.extractNonEmptyJsonArrayFromBody;
+import static org.swisspush.redisques.util.RedisquesAPI.BAD_INPUT;
+import static org.swisspush.redisques.util.RedisquesAPI.COUNT;
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR_TYPE;
+import static org.swisspush.redisques.util.RedisquesAPI.FILTER;
+import static org.swisspush.redisques.util.RedisquesAPI.LIMIT;
+import static org.swisspush.redisques.util.RedisquesAPI.LOCKS;
+import static org.swisspush.redisques.util.RedisquesAPI.MEMORY_FULL;
+import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
+import static org.swisspush.redisques.util.RedisquesAPI.MONITOR_QUEUE_NAME;
+import static org.swisspush.redisques.util.RedisquesAPI.MONITOR_QUEUE_SIZE;
+import static org.swisspush.redisques.util.RedisquesAPI.NO_SUCH_LOCK;
+import static org.swisspush.redisques.util.RedisquesAPI.OK;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
+import static org.swisspush.redisques.util.RedisquesAPI.STATISTIC_QUEUE_DEQUEUESTATISTIC;
+import static org.swisspush.redisques.util.RedisquesAPI.STATISTIC_QUEUE_LAST_DEQUEUE_ATTEMPT;
+import static org.swisspush.redisques.util.RedisquesAPI.STATISTIC_QUEUE_LAST_DEQUEUE_SUCCESS;
+import static org.swisspush.redisques.util.RedisquesAPI.STATISTIC_QUEUE_NEXT_DEQUEUE_DUE_TS;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
+import static org.swisspush.redisques.util.RedisquesAPI.VALUE;
+import static org.swisspush.redisques.util.RedisquesAPI.buildAddQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkDeleteQueuesOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildBulkPutLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteAllQueueItemsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildDeleteQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildEnqueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetAllLocksOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetConfigurationOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueueItemsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesItemsCountOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesSpeedOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildGetQueuesStatisticsOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildLockedEnqueueOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildPutLockOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildReplaceQueueItemOperation;
+import static org.swisspush.redisques.util.RedisquesAPI.buildSetConfigurationOperation;
 
 /**
  * Handler class for HTTP requests providing access to Redisques over HTTP.
@@ -63,13 +113,13 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private final String userHeader;
     private final boolean enableQueueNameDecoding;
     private final int queueSpeedIntervalSec;
-    private final RedisQues redisQues;
+    private final QueueStatisticsCollector queueStatisticsCollector;
 
-    public static void init(Vertx vertx, RedisquesConfiguration modConfig, RedisQues redisQues) {
+    public static void init(Vertx vertx, RedisquesConfiguration modConfig, QueueStatisticsCollector queueStatisticsCollector) {
         log.info("Enable http request handler: " + modConfig.getHttpRequestHandlerEnabled());
         if (modConfig.getHttpRequestHandlerEnabled()) {
             if (modConfig.getHttpRequestHandlerPort() != null && modConfig.getHttpRequestHandlerUserHeader() != null) {
-                RedisquesHttpRequestHandler handler = new RedisquesHttpRequestHandler(vertx, modConfig, redisQues);
+                RedisquesHttpRequestHandler handler = new RedisquesHttpRequestHandler(vertx, modConfig, queueStatisticsCollector);
                 // in Vert.x 2x 100-continues was activated per default, in vert.x 3x it is off per default.
                 HttpServerOptions options = new HttpServerOptions().setHandle100ContinueAutomatically(true);
                 vertx.createHttpServer(options).requestHandler(handler).listen(modConfig.getHttpRequestHandlerPort(), result -> {
@@ -98,14 +148,14 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         return Result.ok(false);
     }
 
-    private RedisquesHttpRequestHandler(Vertx vertx, RedisquesConfiguration modConfig, RedisQues redisQues) {
+    private RedisquesHttpRequestHandler(Vertx vertx, RedisquesConfiguration modConfig, QueueStatisticsCollector queueStatisticsCollector) {
         this.router = Router.router(vertx);
         this.eventBus = vertx.eventBus();
         this.redisquesAddress = modConfig.getAddress();
         this.userHeader = modConfig.getHttpRequestHandlerUserHeader();
         this.enableQueueNameDecoding = modConfig.getEnableQueueNameDecoding();
         this.queueSpeedIntervalSec = modConfig.getQueueSpeedIntervalSec();
-        this.redisQues = redisQues;
+        this.queueStatisticsCollector = queueStatisticsCollector;
 
         final String prefix = modConfig.getHttpRequestHandlerPrefix();
 
@@ -512,12 +562,13 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                     if (limit > 0) {
                         queuesList = limitJsonQueueArray(queuesList, limit);
                     }
-                    Map<String, RedisQues.DequeueStatistic> dequeueProcessStatistic = redisQues.getDequeueStatistic();
-                    fillStatisticToQueuesList(queuesList, dequeueProcessStatistic);
 
-                    JsonObject resultObject = new JsonObject();
-                    resultObject.put(QUEUES, queuesList);
-                    jsonResponse(ctx.response(), resultObject);
+                    // this function always Success
+                    fillStatisticToQueuesList(queuesList).onSuccess(updatedQueuesList -> {
+                        JsonObject resultObject = new JsonObject();
+                        resultObject.put(QUEUES, updatedQueuesList);
+                        jsonResponse(ctx.response(), resultObject);
+                    });
                 } else {
                     // there was no result, we as well return an empty result
                     JsonObject resultObject = new JsonObject();
@@ -532,25 +583,53 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         });
     }
 
-    private void fillStatisticToQueuesList(List<JsonObject> queuesList, Map<String, RedisQues.DequeueStatistic> dequeueProcessStatistic) {
-        queuesList.forEach(entries -> {
-            String queueName = entries.getString(MONITOR_QUEUE_NAME);
-            entries.put(MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT, "");
-            entries.put(MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS, "");
-            entries.put(MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS, "");
-            if (dequeueProcessStatistic.containsKey(queueName)) {
-                RedisQues.DequeueStatistic dequeueStatistic = dequeueProcessStatistic.get(queueName);
-                if (dequeueStatistic.lastDequeueAttemptTimestamp != null) {
-                    entries.put(MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueAttemptTimestamp)));
-                }
-                if (dequeueStatistic.lastDequeueSuccessTimestamp != null) {
-                    entries.put(MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueSuccessTimestamp)));
-                }
-                if (dequeueStatistic.nextDequeueDueTimestamp != null) {
-                    entries.put(MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS, DATE_FORMAT.format(new Date(dequeueStatistic.nextDequeueDueTimestamp)));
-                }
-            }
-        });
+    private Future<List<JsonObject>> fillStatisticToQueuesList(List<JsonObject> queuesList) {
+        Promise<List<JsonObject>> promise = Promise.promise();
+        List<String> queueNameList = new ArrayList<>();
+        for (JsonObject jsonObject : queuesList)
+        {
+            queueNameList.add(jsonObject.getString(MONITOR_QUEUE_NAME));
+        }
+
+        queueStatisticsCollector.getQueueStatistics(queueNameList)
+                .onFailure(ex -> {
+                    log.error("Failed to fetch QueueStatistics for queue", ex);
+                    promise.complete(queuesList);
+                })
+                .onSuccess(queueStatisticsJsonObject -> {
+                    if (OK.equals(queueStatisticsJsonObject.getString(STATUS))
+                            && !queueStatisticsJsonObject.getJsonArray(QUEUES).isEmpty()) {
+                        JsonArray queueStatisticsArray = queueStatisticsJsonObject.getJsonArray(QUEUES);
+                        queuesList.forEach(entries -> {
+                            String queueName = entries.getString(MONITOR_QUEUE_NAME);
+                            entries.put(STATISTIC_QUEUE_LAST_DEQUEUE_ATTEMPT, "");
+                            entries.put(STATISTIC_QUEUE_LAST_DEQUEUE_SUCCESS, "");
+                            entries.put(STATISTIC_QUEUE_NEXT_DEQUEUE_DUE_TS, "");
+                            queueStatisticsJsonObject.getJsonArray(QUEUES);
+
+                            for (Iterator<Object> it = queueStatisticsArray.stream().iterator(); it.hasNext(); ) {
+                                JsonObject queueStatistic = (JsonObject) it.next();
+                                if (queueName.equals(queueStatistic.getString(MONITOR_QUEUE_NAME))
+                                && queueStatistic.containsKey(STATISTIC_QUEUE_DEQUEUESTATISTIC)
+                                && queueStatistic.getJsonObject(STATISTIC_QUEUE_DEQUEUESTATISTIC) != null) {
+                                    DequeueStatistic dequeueStatistic = queueStatistic.getJsonObject(STATISTIC_QUEUE_DEQUEUESTATISTIC).mapTo(DequeueStatistic.class);
+                                    if (dequeueStatistic.lastDequeueAttemptTimestamp != null) {
+                                        entries.put(STATISTIC_QUEUE_LAST_DEQUEUE_ATTEMPT, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueAttemptTimestamp)));
+                                    }
+                                    if (dequeueStatistic.lastDequeueSuccessTimestamp != null) {
+                                        entries.put(STATISTIC_QUEUE_LAST_DEQUEUE_SUCCESS, DATE_FORMAT.format(new Date(dequeueStatistic.lastDequeueSuccessTimestamp)));
+                                    }
+                                    if (dequeueStatistic.nextDequeueDueTimestamp != null) {
+                                        entries.put(STATISTIC_QUEUE_NEXT_DEQUEUE_DUE_TS, DATE_FORMAT.format(new Date(dequeueStatistic.nextDequeueDueTimestamp)));
+                                    }
+                                    break;
+                                }
+                            }
+                        });
+                    }
+                    promise.complete(queuesList);
+                });
+        return promise.future();
     }
 
 

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
@@ -1,0 +1,14 @@
+package org.swisspush.redisques.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DequeueStatistic {
+    public Long lastDequeueAttemptTimestamp = null;
+    public Long lastDequeueSuccessTimestamp = null;
+    public Long nextDequeueDueTimestamp = null;
+
+    public boolean isEmpty() {
+        return lastDequeueAttemptTimestamp == null && lastDequeueSuccessTimestamp == null && nextDequeueDueTimestamp == null;
+    }
+}

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -460,7 +460,13 @@ public class QueueStatisticsCollector {
         }
         var ctx = new RequestCtx();
         ctx.queueNames = queues;
-        step1(ctx).onComplete(promise);
+        step1(ctx).compose(
+                jsonObject1 -> step2(ctx).compose(
+                        jsonObject2 -> step3(ctx).compose(
+                                jsonObject3 -> step4(ctx).compose(
+                                        jsonObject4 -> step5(ctx).compose(
+                                                jsonObject5 -> step6(ctx))
+                                )))).onComplete(promise);
         return promise.future();
     }
 
@@ -474,7 +480,7 @@ public class QueueStatisticsCollector {
                 .onSuccess(conn -> {
                     assert conn != null;
                     ctx.conn = conn;
-                    step2(ctx).onComplete(promise);
+                    promise.complete();
                 });
         return promise.future();
     }
@@ -503,7 +509,7 @@ public class QueueStatisticsCollector {
                         return;
                     }
                     ctx.queueLengthList = queueLengthList;
-                    step3(ctx).onComplete(promise);
+                    promise.complete();
                 });
         return promise.future();
     }
@@ -520,7 +526,7 @@ public class QueueStatisticsCollector {
             qs.setMessageSpeed(getQueueSpeed(qs.queueName));
             ctx.statistics.put(qs.queueName, qs);
         }
-        step4(ctx).onComplete(promise);
+        promise.complete();
         return promise.future();
     }
 
@@ -534,7 +540,7 @@ public class QueueStatisticsCollector {
                 .onSuccess(redisAPI -> {
                     assert redisAPI != null;
                     ctx.redisAPI = redisAPI;
-                    step5(ctx).onComplete(promise);
+                    promise.complete();
                 });
         return promise.future();
     }
@@ -555,7 +561,7 @@ public class QueueStatisticsCollector {
             }
             ctx.redisFailStats = statisticsSet.result();
             assert ctx.redisFailStats != null;
-            step6(ctx).onComplete(promise);
+            promise.complete();
         });
         return promise.future();
     }

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -450,6 +450,7 @@ public class QueueStatisticsCollector {
      *
      * @return A Future
      */
+
     public Future<JsonObject> getQueueStatistics(final List<String> queues) {
         Promise<JsonObject> promise = Promise.promise();
         if (queues == null || queues.isEmpty()) {
@@ -457,147 +458,55 @@ public class QueueStatisticsCollector {
             promise.complete(new JsonObject().put(STATUS, OK).put(RedisquesAPI.QUEUES, new JsonArray()));
             return promise.future();
         }
-        redisProvider.connection().onSuccess(conn -> {
-            List<Future> responses = queues.stream().map(queue -> conn.send(Request.cmd(Command.LLEN, queuePrefix + queue))
-            ).collect(Collectors.toList());
-            CompositeFuture.all(responses).onFailure(throwable -> {
-                promise.fail("Unexpected queue length result");
-            }).onSuccess(compositeFuture -> {
-                List<NumberType> queueLengthList = compositeFuture.list();
-                if (queueLengthList == null) {
-                    promise.fail("Unexpected queue length result null");
-                    return;
-                }
-                if (queueLengthList.size() != queues.size()) {
-                    String err = "Unexpected queue length result with unequal size " + queues.size() + " : " + queueLengthList.size();
-                    promise.fail(err);
-                    return;
-                }
-                // populate the list of queue statistics in a Hashmap for later fast merging
-                final HashMap<String, QueueStatistic> statisticsMap = new HashMap<>();
-                for (int i = 0; i < queues.size(); i++) {
-                    QueueStatistic qs = new QueueStatistic(queues.get(i));
-                    qs.setSize(queueLengthList.get(i).toLong());
-                    qs.setMessageSpeed(getQueueSpeed(qs.queueName));
-                    statisticsMap.put(qs.queueName, qs);
-                }
-                // now retrieve all available failure statistics from Redis and merge them
-                // together with the previous populated common queue statistics map
-                redisProvider.redis().onSuccess(redisAPI -> redisAPI.hvals(STATSKEY, statisticsSet -> {
-                    if (statisticsSet == null) {
-                        promise.fail("Unexpected statistics queue evaluation result result null");
-                        return;
-                    }
-                    // put the received statistics data to the former prepared statistics objects
-                    // per queue
-                    for (Response response : statisticsSet.result()) {
-                        JsonObject jObj = new JsonObject(response.toString());
-                        String queueName = jObj.getString(QUEUENAME);
-                        QueueStatistic queueStatistic = statisticsMap.get(queueName);
-                        if (queueStatistic != null) {
-                            // if it isn't there, there is obviously no statistic needed
-                            queueStatistic.setFailures(jObj.getLong(QUEUE_FAILURES, 0L));
-                            queueStatistic.setBackpressureTime(jObj.getLong(QUEUE_BACKPRESSURE, 0L));
-                            queueStatistic.setSlowdownTime(jObj.getLong(QUEUE_SLOWDOWNTIME, 0L));
-                            if (jObj.containsKey(QUEUE_DEQUEUE_STATISTIC)) {
-                                queueStatistic.setDequeueStatistic(jObj.getJsonObject(QUEUE_DEQUEUE_STATISTIC).mapTo(DequeueStatistic.class));
-                            }
-                        }
-                    }
-                    // build the final resulting statistics list from the former merged queue
-                    // values from various sources
-                    JsonArray result = new JsonArray();
-                    for (String queueName : queues) {
-                        QueueStatistic stats = statisticsMap.get(queueName);
-                        if (stats != null) {
-                            result.add(stats.getAsJsonObject());
-                        }
-                    }
-                    promise.complete(new JsonObject().put(STATUS, OK)
-                            .put(RedisquesAPI.QUEUES, result));
-                })).onFailure(throwable -> {
-                    promise.fail(new Exception("Redis: Error in getQueueStatistics", throwable));
-                });
-
-            });
-        }).onFailure(throwable -> {
-            promise.fail(new Exception("Redis: Failed to get queue length.", throwable));
-        });
+        var ctx = new RequestCtx();
+        ctx.queueNames = queues;
+        step1(ctx, promise);
         return promise.future();
-        var ctx = new RequestCtx();
-        ctx.event = event;
-        ctx.queueNames = queues;
-        step1(ctx);
-    }
-
-    /**
-     * Retrieve the queue statistics for the requested queues.
-     * <p>
-     * Note: This operation does interact with Redis to retrieve the values for the statistics
-     * for all queues requested (independent of the redisques instance for which the queues are
-     * registered). Therefore this method must be used with care and not be called too often!
-     *
-     * @param event  The event on which we will answer finally
-     * @param queues The queues for which we are interested in the statistics
-     */
-    public void getQueueStatistics(Message<JsonObject> event, final List<String> queues) {
-        if (queues == null || queues.isEmpty()) {
-            log.debug("Queue statistics evaluation with empty queues, returning empty result");
-            event.reply(new JsonObject().put(STATUS, OK).put(RedisquesAPI.QUEUES, new JsonArray()));
-            return;
-        }
-        var ctx = new RequestCtx();
-        ctx.event = event;
-        ctx.queueNames = queues;
-        step1(ctx);
     }
 
     /** <p>init redis connection.</p> */
-    void step1(RequestCtx ctx) {
+    void step1(RequestCtx ctx, Promise<JsonObject> promise) {
         redisProvider.connection()
-                .onFailure(ex -> {
-                    log.warn("Redis: Failed to get queue length.", new Exception(ex));
-                    ctx.event.reply(new JsonObject().put(STATUS, ERROR));
+                .onFailure(throwable -> {
+                    promise.fail(new Exception("Redis: Failed to get queue length.", throwable));
                 })
                 .onSuccess(conn -> {
                     assert conn != null;
                     ctx.conn = conn;
-                    step2(ctx);
+                    step2(ctx, promise);
                 });
     }
 
     /** <p>Query queue lengths.</p> */
-    void step2(RequestCtx ctx) {
+    void step2(RequestCtx ctx, Promise<JsonObject> promise) {
         assert ctx.conn != null;
         List<Future> responses = ctx.queueNames.stream()
                 .map(queue -> ctx.conn.send(Request.cmd(Command.LLEN, queuePrefix + queue)))
                 .collect(Collectors.toList());
         CompositeFuture.all(responses)
                 .onFailure(ex -> {
-                    log.warn("Unexpected queue length result", new Exception(ex));
-                    ctx.event.reply(new JsonObject().put(STATUS, ERROR));
+                    promise.fail("Unexpected queue length result");
                 })
                 .onSuccess(compositeFuture -> {
                     List<NumberType> queueLengthList = compositeFuture.list();
                     if (queueLengthList == null) {
-                        log.warn("Unexpected queue length result: null");
-                        ctx.event.reply(new JsonObject().put(STATUS, ERROR));
+                        promise.fail("Unexpected queue length result: null");
                         return;
                     }
                     if (queueLengthList.size() != ctx.queueNames.size()) {
-                        log.error("Unexpected queue length result with unequal size {} : {}",
-                                ctx.queueNames.size(), queueLengthList.size());
-                        ctx.event.reply(new JsonObject().put(STATUS, ERROR));
+                        String err = "Unexpected queue length result with unequal size " +
+                                ctx.queueNames.size() + " : " + queueLengthList.size();
+                        promise.fail(err);
                         return;
                     }
                     ctx.queueLengthList = queueLengthList;
-                    step3(ctx);
+                    step3(ctx, promise);
                 })
         ;
     }
 
     /** <p>init queue statistics.</p> */
-    void step3(RequestCtx ctx) {
+    void step3(RequestCtx ctx, Promise<JsonObject> promise) {
         assert ctx.queueLengthList != null;
         // populate the list of queue statistics in a Hashmap for later fast merging
         ctx.statistics = new HashMap<>(ctx.queueNames.size());
@@ -607,20 +516,19 @@ public class QueueStatisticsCollector {
             qs.setMessageSpeed(getQueueSpeed(qs.queueName));
             ctx.statistics.put(qs.queueName, qs);
         }
-        step4(ctx);
+        step4(ctx, promise);
     }
 
     /** <p>init a resAPI instance we need to get more details.</p> */
-    void step4(RequestCtx ctx){
+    void step4(RequestCtx ctx, Promise<JsonObject> promise){
         redisProvider.redis()
-                .onFailure(ex -> {
-                    log.error("Redis: Error in getQueueStatistics", new Exception(ex));
-                    ctx.event.reply(new JsonObject().put(STATUS, ERROR));
+                .onFailure(throwable -> {
+                    promise.fail(new Exception("Redis: Error in getQueueStatistics", throwable));
                 })
                 .onSuccess(redisAPI -> {
                     assert redisAPI != null;
                     ctx.redisAPI = redisAPI;
-                    step5(ctx);
+                    step5(ctx, promise);
                 })
         ;
     }
@@ -629,25 +537,24 @@ public class QueueStatisticsCollector {
      * <p>retrieve all available failure statistics from Redis and merge them
      * together with the previous populated common queue statistics map</p>
      */
-    void step5(RequestCtx ctx) {
+    void step5(RequestCtx ctx, Promise<JsonObject> promise) {
         assert ctx.redisAPI != null;
         assert ctx.statistics != null;
         ctx.redisAPI.hvals(STATSKEY, statisticsSet -> {
             if( statisticsSet == null || statisticsSet.failed() ){
-                log.error("statistics queue evaluation failed",
-                        statisticsSet == null ? null : statisticsSet.cause());
-                ctx.event.reply(new JsonObject().put(STATUS, ERROR));
+                promise.fail(new RuntimeException("statistics queue evaluation failed",
+                        statisticsSet == null ? null : statisticsSet.cause()));
                 return;
             }
             ctx.redisFailStats = statisticsSet.result();
             assert ctx.redisFailStats != null;
-            step6(ctx);
+            step6(ctx, promise);
         });
     }
 
     /** <p>put received statistics data to the former prepared statistics objects per
      *  queue.</p> */
-    void step6(RequestCtx ctx ){
+    void step6(RequestCtx ctx, Promise<JsonObject> promise){
         assert ctx.redisFailStats != null;
         for (Response response : ctx.redisFailStats) {
             JsonObject jObj = new JsonObject(response.toString());
@@ -658,6 +565,9 @@ public class QueueStatisticsCollector {
                 queueStatistic.setFailures(jObj.getLong(QUEUE_FAILURES, 0L));
                 queueStatistic.setBackpressureTime(jObj.getLong(QUEUE_BACKPRESSURE, 0L));
                 queueStatistic.setSlowdownTime(jObj.getLong(QUEUE_SLOWDOWNTIME, 0L));
+                if (jObj.containsKey(QUEUE_DEQUEUE_STATISTIC)) {
+                    queueStatistic.setDequeueStatistic(jObj.getJsonObject(QUEUE_DEQUEUE_STATISTIC).mapTo(DequeueStatistic.class));
+                }
             }
         }
         // build the final resulting statistics list from the former merged queue
@@ -669,7 +579,7 @@ public class QueueStatisticsCollector {
                 result.add(stats.getAsJsonObject());
             }
         }
-        ctx.event.reply(new JsonObject().put(STATUS, OK)
+        promise.complete(new JsonObject().put(STATUS, OK)
                 .put(RedisquesAPI.QUEUES, result));
     }
 

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -41,6 +41,8 @@ public class RedisquesAPI {
 
     public static final String MONITOR_QUEUE_NAME = "name";
     public static final String MONITOR_QUEUE_SIZE = "size";
+    public static final String MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT = "lastDequeueAttempt";
+    public static final String MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS = "lastDequeueSuccess";
     public static final String STATISTIC_QUEUE_FAILURES = "failures";
     public static final String STATISTIC_QUEUE_BACKPRESSURE = "backpressureTime";
     public static final String STATISTIC_QUEUE_SLOWDOWN = "slowdownTime";

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -41,13 +41,14 @@ public class RedisquesAPI {
 
     public static final String MONITOR_QUEUE_NAME = "name";
     public static final String MONITOR_QUEUE_SIZE = "size";
-    public static final String MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT = "lastDequeueAttempt";
-    public static final String MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS = "lastDequeueSuccess";
-    public static final String MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS = "nextDequeueDueTimestamp";
+    public static final String STATISTIC_QUEUE_LAST_DEQUEUE_ATTEMPT = "lastDequeueAttempt";
+    public static final String STATISTIC_QUEUE_LAST_DEQUEUE_SUCCESS = "lastDequeueSuccess";
+    public static final String STATISTIC_QUEUE_NEXT_DEQUEUE_DUE_TS = "nextDequeueDueTimestamp";
     public static final String STATISTIC_QUEUE_FAILURES = "failures";
     public static final String STATISTIC_QUEUE_BACKPRESSURE = "backpressureTime";
     public static final String STATISTIC_QUEUE_SLOWDOWN = "slowdownTime";
     public static final String STATISTIC_QUEUE_SPEED = "speed";
+    public final static String STATISTIC_QUEUE_DEQUEUESTATISTIC = "dequeueStatistic";
     public static final String STATISTIC_QUEUE_SPEED_INTERVAL_UNIT= "unitSec";
 
     private static final Logger log = LoggerFactory.getLogger(RedisquesAPI.class);

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -43,6 +43,7 @@ public class RedisquesAPI {
     public static final String MONITOR_QUEUE_SIZE = "size";
     public static final String MONITOR_QUEUE_LAST_DEQUEUE_ATTEMPT = "lastDequeueAttempt";
     public static final String MONITOR_QUEUE_LAST_DEQUEUE_SUCCESS = "lastDequeueSuccess";
+    public static final String MONITOR_QUEUE_NEXT_DEQUEUE_DUE_TS = "nextDequeueDueTimestamp";
     public static final String STATISTIC_QUEUE_FAILURES = "failures";
     public static final String STATISTIC_QUEUE_BACKPRESSURE = "backpressureTime";
     public static final String STATISTIC_QUEUE_SLOWDOWN = "slowdownTime";

--- a/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
@@ -50,6 +50,7 @@ public class RedisquesConfiguration {
     private final int redisReconnectAttempts;
     private final int redisReconnectDelaySec;
     private final int redisPoolRecycleTimeoutMs;
+    private final int dequeueStatisticReportIntervalSec;
 
     private static final int DEFAULT_CHECK_INTERVAL_S = 60; // 60s
     private static final int DEFAULT_PROCESSOR_TIMEOUT_MS = 240000; // 240s
@@ -69,6 +70,7 @@ public class RedisquesConfiguration {
     private static final int DEFAULT_QUEUE_SPEED_INTERVAL_SEC = 60;
     private static final int DEFAULT_MEMORY_USAGE_LIMIT_PCT = 100;
     private static final int DEFAULT_MEMORY_USAGE_CHECK_INTERVAL_SEC = 60;
+    private static final int DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC = 30;
 
     public static final String PROP_ADDRESS = "address";
     public static final String PROP_CONFIGURATION_UPDATED_ADDRESS = "configuration-updated-address";
@@ -109,6 +111,7 @@ public class RedisquesConfiguration {
     public static final String PROP_QUEUE_SPEED_INTERVAL_SEC = "queueSpeedIntervalSec";
     public static final String PROP_MEMORY_USAGE_LIMIT_PCT = "memoryUsageLimitPercent";
     public static final String PROP_MEMORY_USAGE_CHECK_INTERVAL_SEC = "memoryUsageCheckIntervalSec";
+    public static final String PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC = "dequeueStatisticReportIntervalSec";
 
     /**
      * Constructor with default values. Use the {@link RedisquesConfigurationBuilder} class
@@ -138,7 +141,7 @@ public class RedisquesConfiguration {
                 enableQueueNameDecoding, DEFAULT_REDIS_MAX_POOL_SIZE, DEFAULT_REDIS_MAX_POOL_WAIT_SIZE,
                 DEFAULT_REDIS_MAX_PIPELINE_WAIT_SIZE, DEFAULT_QUEUE_SPEED_INTERVAL_SEC, DEFAULT_MEMORY_USAGE_LIMIT_PCT,
                 DEFAULT_MEMORY_USAGE_CHECK_INTERVAL_SEC, DEFAULT_REDIS_RECONNECT_ATTEMPTS, DEFAULT_REDIS_RECONNECT_DELAY_SEC,
-                DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS);
+                DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC);
     }
 
     /**
@@ -159,7 +162,7 @@ public class RedisquesConfiguration {
                 enableQueueNameDecoding, DEFAULT_REDIS_MAX_POOL_SIZE, DEFAULT_REDIS_MAX_POOL_WAIT_SIZE,
                 DEFAULT_REDIS_MAX_PIPELINE_WAIT_SIZE, DEFAULT_QUEUE_SPEED_INTERVAL_SEC, DEFAULT_MEMORY_USAGE_LIMIT_PCT,
                 DEFAULT_MEMORY_USAGE_CHECK_INTERVAL_SEC, DEFAULT_REDIS_RECONNECT_ATTEMPTS, DEFAULT_REDIS_RECONNECT_DELAY_SEC,
-                DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS);
+                DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC);
     }
 
     /**
@@ -179,7 +182,7 @@ public class RedisquesConfiguration {
                 enableQueueNameDecoding, DEFAULT_REDIS_MAX_POOL_SIZE, DEFAULT_REDIS_MAX_POOL_WAIT_SIZE,
                 DEFAULT_REDIS_MAX_PIPELINE_WAIT_SIZE, DEFAULT_QUEUE_SPEED_INTERVAL_SEC, DEFAULT_MEMORY_USAGE_LIMIT_PCT,
                 DEFAULT_MEMORY_USAGE_CHECK_INTERVAL_SEC, DEFAULT_REDIS_RECONNECT_ATTEMPTS, DEFAULT_REDIS_RECONNECT_DELAY_SEC,
-                DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS);
+                DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC);
     }
 
     private RedisquesConfiguration(String address, String configurationUpdatedAddress, String redisPrefix, String processorAddress, int refreshPeriod,
@@ -191,7 +194,8 @@ public class RedisquesConfiguration {
                                    List<QueueConfiguration> queueConfigurations, boolean enableQueueNameDecoding,
                                    int maxPoolSize, int maxPoolWaitSize, int maxPipelineWaitSize,
                                    int queueSpeedIntervalSec, int memoryUsageLimitPercent, int memoryUsageCheckIntervalSec,
-                                   int redisReconnectAttempts, int redisReconnectDelaySec, int redisPoolRecycleTimeoutMs) {
+                                   int redisReconnectAttempts, int redisReconnectDelaySec, int redisPoolRecycleTimeoutMs,
+                                   int dequeueStatisticReportIntervalSec) {
         this.address = address;
         this.configurationUpdatedAddress = configurationUpdatedAddress;
         this.redisPrefix = redisPrefix;
@@ -268,6 +272,7 @@ public class RedisquesConfiguration {
         }
 
         this.redisPoolRecycleTimeoutMs = redisPoolRecycleTimeoutMs;
+        this.dequeueStatisticReportIntervalSec = dequeueStatisticReportIntervalSec;
     }
 
     public static RedisquesConfigurationBuilder with() {
@@ -289,7 +294,8 @@ public class RedisquesConfiguration {
                 builder.memoryUsageCheckIntervalSec,
                 builder.redisReconnectAttempts,
                 builder.redisReconnectDelaySec,
-                builder.redisPoolRecycleTimeoutMs);
+                builder.redisPoolRecycleTimeoutMs,
+                builder.dequeueStatisticReportIntervalSec);
     }
 
     public JsonObject asJsonObject() {
@@ -329,6 +335,7 @@ public class RedisquesConfiguration {
         obj.put(PROP_QUEUE_SPEED_INTERVAL_SEC, getQueueSpeedIntervalSec());
         obj.put(PROP_MEMORY_USAGE_LIMIT_PCT, getMemoryUsageLimitPercent());
         obj.put(PROP_MEMORY_USAGE_CHECK_INTERVAL_SEC, getMemoryUsageCheckIntervalSec());
+        obj.put(PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC, getDequeueStatisticReportIntervalSec());
         return obj;
     }
 
@@ -442,6 +449,9 @@ public class RedisquesConfiguration {
         if (json.containsKey(PROP_MEMORY_USAGE_CHECK_INTERVAL_SEC)) {
             builder.memoryUsageCheckIntervalSec(json.getInteger(PROP_MEMORY_USAGE_CHECK_INTERVAL_SEC));
         }
+        if (json.containsKey(PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC)) {
+            builder.dequeueStatisticReportIntervalSec(json.getInteger(PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC));
+        }
         return builder.build();
     }
 
@@ -490,6 +500,9 @@ public class RedisquesConfiguration {
 
     public int getRedisPoolRecycleTimeoutMs() {
         return redisPoolRecycleTimeoutMs;
+    }
+    public int getDequeueStatisticReportIntervalSec() {
+        return dequeueStatisticReportIntervalSec;
     }
 
     public String getRedisAuth() {
@@ -636,6 +649,7 @@ public class RedisquesConfiguration {
         private int redisReconnectAttempts;
         private int redisReconnectDelaySec;
         private int redisPoolRecycleTimeoutMs;
+        private int dequeueStatisticReportIntervalSec;
         private RedisClientType redisClientType;
         private String redisAuth;
         private String redisPassword;
@@ -691,6 +705,7 @@ public class RedisquesConfiguration {
             this.queueSpeedIntervalSec = DEFAULT_QUEUE_SPEED_INTERVAL_SEC;
             this.memoryUsageLimitPercent = DEFAULT_MEMORY_USAGE_LIMIT_PCT;
             this.memoryUsageCheckIntervalSec = DEFAULT_MEMORY_USAGE_CHECK_INTERVAL_SEC;
+            this.dequeueStatisticReportIntervalSec = DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC;
         }
 
         public RedisquesConfigurationBuilder address(String address) {
@@ -868,6 +883,10 @@ public class RedisquesConfiguration {
             return this;
         }
 
+        public RedisquesConfigurationBuilder dequeueStatisticReportIntervalSec(int dequeueStatisticReportIntervalSec) {
+            this.dequeueStatisticReportIntervalSec = dequeueStatisticReportIntervalSec;
+            return this;
+        }
         public RedisquesConfiguration build() {
             return new RedisquesConfiguration(this);
         }

--- a/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
@@ -126,7 +126,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
     private static final String configurationEmpty = "{}";
 
     @Rule
-    public Timeout rule = Timeout.seconds(15);
+    public Timeout rule = Timeout.seconds(35);
 
     @BeforeClass
     public static void beforeClass() {
@@ -154,6 +154,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
                                 .withEnqueueDelayMillisPerSize(5).withEnqueueMaxDelayMillis(100)
                 ))
                 .queueSpeedIntervalSec(4)
+                .dequeueStatisticReportIntervalSec(5)
                 .build()
                 .asJsonObject();
 
@@ -1891,6 +1892,12 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
         given().body("{}").when().put("/queuing/locks/queue_3").then().assertThat().statusCode(200);
         when().delete("/queuing/queues/queue_3/0").then().assertThat().statusCode(200);
 
+        // wait 5.1 second, because the update time is 5 seconds
+        try {
+            Thread.sleep(5100);
+        } catch (InterruptedException iex) {
+            // ignore
+        }
         String expectedNoEmptyQueuesNoLimit = "{\n" +
                 "  \"queues\": [\n" +
                 "    {\n" +
@@ -1904,9 +1911,14 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
                 "  ]\n" +
                 "}";
         JsonNode expectedStaticJson = jsonMapper.readTree(expectedNoEmptyQueuesNoLimit);
-        JsonNode receivedJson = jsonMapper.readTree( when().get("/queuing/monitor").then().assertThat().statusCode(200).extract().asString());
+        JsonNode receivedJson = jsonMapper.readTree(when().get("/queuing/monitor").then().assertThat().statusCode(200).extract().asString());
         verifyResponse(context, expectedStaticJson, receivedJson);
-
+        // wait 5.1 second, because the update time is 5 seconds
+        try {
+            Thread.sleep(5100);
+        } catch (InterruptedException iex) {
+            // ignore
+        }
         String expectedWithEmptyQueuesNoLimit = "{\n" +
                 "  \"queues\": [\n" +
                 "    {\n" +
@@ -1925,9 +1937,14 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
                 "}";
 
         expectedStaticJson = jsonMapper.readTree(expectedWithEmptyQueuesNoLimit);
-        receivedJson = jsonMapper.readTree( when().get("/queuing/monitor?emptyQueues").then().assertThat().statusCode(200).extract().asString());
+        receivedJson = jsonMapper.readTree(when().get("/queuing/monitor?emptyQueues").then().assertThat().statusCode(200).extract().asString());
         verifyResponse(context, expectedStaticJson, receivedJson);
-
+        // wait 5.1 second, because the update time is 5 seconds
+        try {
+            Thread.sleep(5100);
+        } catch (InterruptedException iex) {
+            // ignore
+        }
         String expectedNoEmptyQueuesAndLimit3 = "{\n" +
                 "  \"queues\": [\n" +
                 "    {\n" +
@@ -1942,9 +1959,14 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
                 "}";
 
         expectedStaticJson = jsonMapper.readTree(expectedNoEmptyQueuesAndLimit3);
-        receivedJson = jsonMapper.readTree( when().get("/queuing/monitor?limit=3").then().assertThat().statusCode(200).extract().asString());
+        receivedJson = jsonMapper.readTree(when().get("/queuing/monitor?limit=3").then().assertThat().statusCode(200).extract().asString());
         verifyResponse(context, expectedStaticJson, receivedJson);
-
+        // wait 5.1 second, because the update time is 5 seconds
+        try {
+            Thread.sleep(5100);
+        } catch (InterruptedException iex) {
+            // ignore
+        }
         String expectedWithEmptyQueuesAndLimit3 = "{\n" +
                 "  \"queues\": [\n" +
                 "    {\n" +
@@ -1963,9 +1985,14 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
                 "}";
 
         expectedStaticJson = jsonMapper.readTree(expectedWithEmptyQueuesAndLimit3);
-        receivedJson = jsonMapper.readTree( when().get("/queuing/monitor?limit=3&emptyQueues").then().assertThat().statusCode(200).extract().asString());
+        receivedJson = jsonMapper.readTree(when().get("/queuing/monitor?limit=3&emptyQueues").then().assertThat().statusCode(200).extract().asString());
         verifyResponse(context, expectedStaticJson, receivedJson);
-
+        // wait 5.1 second, because the update time is 5 seconds
+        try {
+            Thread.sleep(5100);
+        } catch (InterruptedException iex) {
+            // ignore
+        }
         String expectedWithEmptyQueuesAndInvalidLimit = "{\n" +
                 "  \"queues\": [\n" +
                 "    {\n" +
@@ -1984,7 +2011,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
                 "}";
 
         expectedStaticJson = jsonMapper.readTree(expectedWithEmptyQueuesAndInvalidLimit);
-        receivedJson = jsonMapper.readTree( when().get("/queuing/monitor?limit=limit=xx99xx&emptyQueues").then().assertThat().statusCode(200).extract().asString());
+        receivedJson = jsonMapper.readTree(when().get("/queuing/monitor?limit=limit=xx99xx&emptyQueues").then().assertThat().statusCode(200).extract().asString());
         verifyResponse(context, expectedStaticJson, receivedJson);
 
         async.complete();

--- a/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
@@ -137,6 +137,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getJsonArray(PROP_QUEUE_CONFIGURATIONS).getList().size(), 0);
         testContext.assertEquals(json.getInteger(PROP_QUEUE_SPEED_INTERVAL_SEC), 60);
         testContext.assertEquals(json.getInteger(PROP_MEMORY_USAGE_LIMIT_PCT), 100);
+        testContext.assertEquals(json.getInteger(PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC), 30);
     }
 
     @Test
@@ -163,6 +164,7 @@ public class RedisquesConfigurationTest {
                 ))
                 .queueSpeedIntervalSec(1)
                 .memoryUsageLimitPercent(55)
+                .dequeueStatisticReportIntervalSec(44)
                 .build();
 
         JsonObject json = config.asJsonObject();
@@ -192,7 +194,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getString(PROP_HTTP_REQUEST_HANDLER_USER_HEADER), "x-custom-user-header");
         testContext.assertEquals(json.getInteger(PROP_QUEUE_SPEED_INTERVAL_SEC), 1);
         testContext.assertEquals(json.getInteger(PROP_MEMORY_USAGE_LIMIT_PCT), 55);
-
+        testContext.assertEquals(json.getInteger(PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC), 44);
         // queue configurations
         JsonArray queueConfigurationsJsonArray = json.getJsonArray(PROP_QUEUE_CONFIGURATIONS);
         List<JsonObject> queueConfigurationJsonObjects = queueConfigurationsJsonArray.getList();
@@ -230,6 +232,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getQueueConfigurations().size(), 0);
         testContext.assertEquals(config.getQueueSpeedIntervalSec(), 60);
         testContext.assertEquals(config.getMemoryUsageLimitPercent(), 100);
+        testContext.assertEquals(config.getDequeueStatisticReportIntervalSec(), 30);
     }
 
     @Test
@@ -257,6 +260,7 @@ public class RedisquesConfigurationTest {
         json.put(PROP_HTTP_REQUEST_HANDLER_USER_HEADER, "x-custom-user-header");
         json.put(PROP_QUEUE_SPEED_INTERVAL_SEC, 1);
         json.put(PROP_MEMORY_USAGE_LIMIT_PCT, 75);
+        json.put(PROP_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC, 22);
         json.put(PROP_QUEUE_CONFIGURATIONS, new JsonArray(Collections.singletonList(
                 new QueueConfiguration().withPattern("vehicle-.*")
                         .withRetryIntervals(10, 20, 30, 60)
@@ -285,6 +289,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getHttpRequestHandlerUserHeader(), "x-custom-user-header");
         testContext.assertEquals(config.getQueueSpeedIntervalSec(), 1);
         testContext.assertEquals(config.getMemoryUsageLimitPercent(), 75);
+        testContext.assertEquals(config.getDequeueStatisticReportIntervalSec(), 22);
 
         // queue configurations
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);


### PR DESCRIPTION
With this PR we are able to monitor details regarding the dequeueing, namely

       lastDequeueAttemptTimestamp
       lastDequeueSuccessTimestamp
       nextDequeueDueTimestamp


This allows us to easily identify e.g. 
- an  overload situation where queues are not longer processed (dequeue is no longer attempted)
- dequeue was attempted but failed
