### PR TITLE
fixed retry timestamp

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -691,13 +691,17 @@ public class RedisQues extends AbstractVerticle {
                 boolean success;
                 if (reply.succeeded()) {
                     success = OK.equals(reply.result().body().getString(STATUS));
-                    dequeueStatistic.get(queue).lastDequeueSuccessTimestamp = System.currentTimeMillis();
-                    dequeueStatistic.get(queue).nextDequeueDueTimestamp = null;
+                    if (success) {
+                        dequeueStatistic.get(queue).lastDequeueSuccessTimestamp = System.currentTimeMillis();
+                        dequeueStatistic.get(queue).nextDequeueDueTimestamp = null;
+                    }
                 } else {
                     log.info("RedisQues QUEUE_ERROR: Consumer failed {} queue: {}",
                             uid, queue, new Exception(reply.cause()));
                     success = Boolean.FALSE;
                 }
+
+
                 handler.handle(success);
             });
             updateTimestamp(queue, null);


### PR DESCRIPTION
As per title, small but meaningful fix, we need to check the outcome when setting the timestamp when we last successfully delivered a queue item to the destination.