### PR TITLE
[SDCISA-15223] Drop logger implementation dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
 
         <!-- TEST dependencies -->
         <dependency>


### PR DESCRIPTION
Libraries must not include logger implementations. It is the applications choice which logger implementation to use. Not a libraries one. Including logger implementations from within libraries defeats the whole purpose of having a logging facade at all. As apps need to configure all logger impls pulled in somewhere by some library deep down the dependency tree.

Example:
```
SLF4J: Class path contains multiple SLF4J providers.
SLF4J: Found provider [org.slf4j.reload4j.Reload4jServiceProvider@3b084709]
SLF4J: Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@3224f60b]
```