### PR TITLE
[SDCISA-13746] Delegate redis hset call to worker thread

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -167,6 +167,10 @@ public class RedisQues extends AbstractVerticle {
         int dequeueStatisticReportInterval = modConfig.getDequeueStatisticReportIntervalSec();
         if (dequeueStatisticReportInterval > 0) {
             vertx.setPeriodic(1000L * dequeueStatisticReportInterval, handler -> {
+                int size = dequeueStatistic.size();
+                if (size > 5_000) log.warn("Going to report {} dequeue statistics towards collector", size);
+                else if (size > 500) log.info("Going to report {} dequeue statistics towards collector", size);
+                else log.debug("Going to report {} dequeue statistics towards collector", size);
                 dequeueStatistic.forEach((queueName, dequeueStatistic) ->
                         queueStatisticsCollector.setDequeueStatistic(queueName, dequeueStatistic));
             });

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
@@ -11,4 +11,11 @@ public class DequeueStatistic {
     public boolean isEmpty() {
         return lastDequeueAttemptTimestamp == null && lastDequeueSuccessTimestamp == null && nextDequeueDueTimestamp == null;
     }
+
+    public void copyDeepTo(DequeueStatistic dst) {
+        dst.lastDequeueAttemptTimestamp = this.lastDequeueAttemptTimestamp;
+        dst.lastDequeueSuccessTimestamp = this.lastDequeueSuccessTimestamp;
+        dst.nextDequeueDueTimestamp = this.nextDequeueDueTimestamp;
+    }
+
 }


### PR DESCRIPTION
One (of many) examples cited from log:

```
2024-04-03T12:18:18,368 test houston WARN BlockedThreadChecker - Thread Thread[vert.x-eventloop-thread-5,5,main] has been blocked for 135 ms, time limit is 8 ms
io.vertx.core.VertxException: Thread blocked
    at sun.nio.ch.FileDispatcherImpl.write0(Native Method) ~[?:?]
    at sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:47) ~[?:?]
    at sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:113) ~[?:?]
    at sun.nio.ch.IOUtil.write(IOUtil.java:58) ~[?:?]
    at sun.nio.ch.IOUtil.write(IOUtil.java:50) ~[?:?]
    at sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:462) ~[?:?]
    at io.netty.channel.socket.nio.NioSocketChannel.doWrite(NioSocketChannel.java:415) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.AbstractChannel$AbstractUnsafe.flush0(AbstractChannel.java:931) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.flush0(AbstractNioChannel.java:355) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.AbstractChannel$AbstractUnsafe.flush(AbstractChannel.java:895) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.DefaultChannelPipeline$HeadContext.flush(DefaultChannelPipeline.java:1372) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeFlush0(AbstractChannelHandlerContext.java:921) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:941) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.vertx.core.net.impl.ConnectionBase.write(ConnectionBase.java:181) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.ConnectionBase.writeToChannel(ConnectionBase.java:233) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.ConnectionBase.writeToChannel(ConnectionBase.java:218) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.ConnectionBase.writeToChannel(ConnectionBase.java:214) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.NetSocketImpl.writeMessage(NetSocketImpl.java:141) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.NetSocketImpl.writeMessage(NetSocketImpl.java:135) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.NetSocketImpl.write(NetSocketImpl.java:152) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.net.impl.NetSocketImpl.write(NetSocketImpl.java:54) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.impl.RedisStandaloneConnection.doSend(RedisStandaloneConnection.java:218) ~[vertx-redis-client-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.impl.RedisStandaloneConnection.lambda$send$0(RedisStandaloneConnection.java:181) ~[vertx-redis-client-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.impl.RedisStandaloneConnection$$Lambda$1631/0x00000008406be440.run(Unknown Source) ~[?:?]
    at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:305) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:295) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.impl.RedisStandaloneConnection.send(RedisStandaloneConnection.java:181) ~[vertx-redis-client-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.impl.PooledRedisConnection.send(PooledRedisConnection.java:75) ~[vertx-redis-client-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.impl.RedisAPIImpl.send(RedisAPIImpl.java:59) ~[vertx-redis-client-4.5.1.jar:4.5.1]
    at io.vertx.redis.client.RedisAPI.hset(RedisAPI.java:2882) ~[vertx-redis-client-4.5.1.jar:4.5.1]
    at org.swisspush.redisques.util.QueueStatisticsCollector.lambda$updateStatisticsInRedis$2(QueueStatisticsCollector.java:349) ~[redisques-3.1.1.jar:?]
    at org.swisspush.redisques.util.QueueStatisticsCollector$$Lambda$2381/0x00000008409ddc40.handle(Unknown Source) ~[?:?]
    at io.vertx.core.impl.future.SucceededFuture.onSuccess(SucceededFuture.java:64) ~[vertx-core-4.5.1.jar:4.5.1]
    at org.swisspush.redisques.util.QueueStatisticsCollector.updateStatisticsInRedis(QueueStatisticsCollector.java:348) ~[redisques-3.1.1.jar:?]
    at org.swisspush.redisques.util.QueueStatisticsCollector.setDequeueStatistic(QueueStatisticsCollector.java:315) ~[redisques-3.1.1.jar:?]
    at org.swisspush.redisques.RedisQues.lambda$start$3(RedisQues.java:171) ~[redisques-3.1.1.jar:?]
    at org.swisspush.redisques.RedisQues$$Lambda$2691/0x0000000840a72c40.accept(Unknown Source) ~[?:?]
    at java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1603) ~[?:?]
    at org.swisspush.redisques.RedisQues.lambda$start$4(RedisQues.java:170) ~[redisques-3.1.1.jar:?]
    at org.swisspush.redisques.RedisQues$$Lambda$1660/0x00000008406ccc40.handle(Unknown Source) ~[?:?]
    at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:1051) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:1027) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:335) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:328) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.impl.ContextInternal.emit(ContextInternal.java:206) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.vertx.core.impl.VertxImpl$InternalTimerHandler.run(VertxImpl.java:1045) ~[vertx-core-4.5.1.jar:4.5.1]
    at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:159) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566) ~[netty-transport-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.103.Final.jar:4.1.103.Final]
    at java.lang.Thread.run(Thread.java:829) ~[?:?]
```
