### PR TITLE
Dequeue monitor timestamps incorrect fixed

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -67,6 +67,7 @@ public class RedisQues extends AbstractVerticle {
     private final Map<String, QueueState> myQueues = new HashMap<>();
 
     private final Logger log = LoggerFactory.getLogger(RedisQues.class);
+    private DequeueStatisticCollector dequeueStatisticCollector;
 
     private QueueStatisticsCollector queueStatisticsCollector;
 
@@ -161,6 +162,11 @@ public class RedisQues extends AbstractVerticle {
         if (this.configurationProvider == null) {
             this.configurationProvider = new DefaultRedisquesConfigurationProvider(vertx, config());
         }
+
+        if (this.dequeueStatisticCollector == null) {
+            this.dequeueStatisticCollector = new DequeueStatisticCollector(vertx);
+        }
+
         RedisquesConfiguration modConfig = configurationProvider.configuration();
         log.info("Starting Redisques module with configuration: {}", configurationProvider.configuration());
 
@@ -168,7 +174,7 @@ public class RedisQues extends AbstractVerticle {
         if (dequeueStatisticReportInterval > 0) {
             vertx.setPeriodic(1000L * dequeueStatisticReportInterval, handler -> {
                 dequeueStatistic.forEach((queueName, dequeueStatistic) ->
-                        queueStatisticsCollector.setDequeueStatistic(queueName, dequeueStatistic));
+                        dequeueStatisticCollector.setDequeueStatistic(queueName, dequeueStatistic));
             });
         }
 
@@ -199,7 +205,7 @@ public class RedisQues extends AbstractVerticle {
         this.queueStatisticsCollector = new QueueStatisticsCollector(redisProvider,
                 queuesPrefix, vertx, configuration.getQueueSpeedIntervalSec());
 
-        RedisquesHttpRequestHandler.init(vertx, configuration, queueStatisticsCollector);
+        RedisquesHttpRequestHandler.init(vertx, configuration, queueStatisticsCollector, dequeueStatisticCollector);
 
         // only initialize memoryUsageProvider when not provided in the constructor
         if (memoryUsageProvider == null) {
@@ -570,7 +576,7 @@ public class RedisQues extends AbstractVerticle {
                     log.trace("RedisQues read queue lindex result: {}", response);
                     if (response != null) {
                         dequeueStatistic.computeIfAbsent(queueName, s -> new DequeueStatistic());
-                        dequeueStatistic.get(queueName).lastDequeueAttemptTimestamp = System.currentTimeMillis();
+                        dequeueStatistic.get(queueName).setLastDequeueAttemptTimestamp(System.currentTimeMillis());
                         processMessageWithTimeout(queueName, response.toString(), success -> {
 
                             // update the queue failure count and get a retry interval
@@ -632,7 +638,7 @@ public class RedisQues extends AbstractVerticle {
                         // This can happen when requests to consume happen at the same moment the queue is emptied.
                         log.debug("Got a request to consume from empty queue {}", queueName);
                         myQueues.put(queueName, QueueState.READY);
-                        dequeueStatistic.remove(queueName);
+                        dequeueStatistic.put(queueName, null);
                         promise.complete();
                     }
                 })).onFailure(throwable -> {
@@ -655,7 +661,7 @@ public class RedisQues extends AbstractVerticle {
 
         vertx.setTimer(retryInSeconds * 1000L, timerId -> {
             long retryDelayInMills = retryInSeconds * 1000L;
-            dequeueStatistic.get(queueName).nextDequeueDueTimestamp = System.currentTimeMillis() + retryDelayInMills;
+            dequeueStatistic.get(queueName).setNextDequeueDueTimestamp(System.currentTimeMillis() + retryDelayInMills);
             if (log.isDebugEnabled()) {
                 log.debug("RedisQues re-notify the consumer of queue '{}' at {}", queueName, new Date(System.currentTimeMillis()));
             }
@@ -692,8 +698,8 @@ public class RedisQues extends AbstractVerticle {
                 if (reply.succeeded()) {
                     success = OK.equals(reply.result().body().getString(STATUS));
                     if (success) {
-                        dequeueStatistic.get(queue).lastDequeueSuccessTimestamp = System.currentTimeMillis();
-                        dequeueStatistic.get(queue).nextDequeueDueTimestamp = null;
+                        dequeueStatistic.get(queue).setLastDequeueSuccessTimestamp(System.currentTimeMillis());
+                        dequeueStatistic.get(queue).setNextDequeueDueTimestamp(null);
                     }
                 } else {
                     log.info("RedisQues QUEUE_ERROR: Consumer failed {} queue: {}",
@@ -851,7 +857,7 @@ public class RedisQues extends AbstractVerticle {
                                 if (log.isTraceEnabled()) {
                                     log.trace("RedisQues remove old queue: {}", queueName);
                                 }
-                                dequeueStatistic.remove(queueName);
+                                dequeueStatistic.put(queueName, null);
                                 if (counter.decrementAndGet() == 0) {
                                     removeOldQueues(limit).onComplete(removeOldQueuesEvent -> {
                                         if( removeOldQueuesEvent.failed() )

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -179,7 +179,7 @@ public class RedisQues extends AbstractVerticle {
                     if (entry.getValue().isMarkToDelete()) {
                         iter.remove();
                     }
-                    dequeueStatisticCollector.setDequeueStatistic((entry.getKey(), entry.getValue());
+                    dequeueStatisticCollector.setDequeueStatistic(entry.getKey(), entry.getValue());
                 }
             });
         }
@@ -648,7 +648,7 @@ public class RedisQues extends AbstractVerticle {
                         dequeueStatistic.computeIfPresent(queueName, (s, dequeueStatistic) -> {
                             dequeueStatistic.setMarkToDelete();
                             return dequeueStatistic;
-                        })
+                        });
 
                         promise.complete();
                     }
@@ -871,7 +871,7 @@ public class RedisQues extends AbstractVerticle {
                                 dequeueStatistic.computeIfPresent(queueName, (s, dequeueStatistic) -> {
                                     dequeueStatistic.setMarkToDelete();
                                     return dequeueStatistic;
-                                })
+                                });
                                 if (counter.decrementAndGet() == 0) {
                                     removeOldQueues(limit).onComplete(removeOldQueuesEvent -> {
                                         if( removeOldQueuesEvent.failed() )

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -107,7 +107,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private static final String EMPTY_QUEUES_PARAM = "emptyQueues";
     private static final String DELETED = "deleted";
 
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd.MM.yyyy hh:mm:ss aaa");
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
 
     private final String redisquesAddress;
     private final String userHeader;

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
@@ -8,6 +8,8 @@ public class DequeueStatistic implements Serializable {
     private Long nextDequeueDueTimestamp = null;
     private Long lastUpdatedTimestamp = null;
 
+    private boolean markToDelete = false;
+
     private void updateLastUpdatedTimestamp() {
         this.lastUpdatedTimestamp = System.currentTimeMillis();
     }
@@ -16,7 +18,7 @@ public class DequeueStatistic implements Serializable {
         return lastDequeueAttemptTimestamp == null && lastDequeueSuccessTimestamp == null && nextDequeueDueTimestamp == null;
     }
 
-    public void setLastDequeueAttemptTimestamp(long timestamp) {
+    public void setLastDequeueAttemptTimestamp(Long timestamp) {
         this.lastDequeueAttemptTimestamp = timestamp;
         updateLastUpdatedTimestamp();
     }
@@ -25,7 +27,7 @@ public class DequeueStatistic implements Serializable {
         return this.lastDequeueAttemptTimestamp;
     }
 
-    public void setLastDequeueSuccessTimestamp(long timestamp) {
+    public void setLastDequeueSuccessTimestamp(Long timestamp) {
         this.lastDequeueSuccessTimestamp = timestamp;
         updateLastUpdatedTimestamp();
     }
@@ -45,5 +47,13 @@ public class DequeueStatistic implements Serializable {
 
     public Long getLastUpdatedTimestamp() {
         return lastUpdatedTimestamp;
+    }
+
+    public void setMarkToDelete() {
+        this.markToDelete = true;
+    }
+
+    public boolean isMarkToDelete() {
+        return this.markToDelete;
     }
 }

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
@@ -1,14 +1,49 @@
 package org.swisspush.redisques.util;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class DequeueStatistic {
-    public Long lastDequeueAttemptTimestamp = null;
-    public Long lastDequeueSuccessTimestamp = null;
-    public Long nextDequeueDueTimestamp = null;
+public class DequeueStatistic implements Serializable {
+    private Long lastDequeueAttemptTimestamp = null;
+    private Long lastDequeueSuccessTimestamp = null;
+    private Long nextDequeueDueTimestamp = null;
+    private Long lastUpdatedTimestamp = null;
+
+    private void updateLastUpdatedTimestamp() {
+        this.lastUpdatedTimestamp = System.currentTimeMillis();
+    }
 
     public boolean isEmpty() {
         return lastDequeueAttemptTimestamp == null && lastDequeueSuccessTimestamp == null && nextDequeueDueTimestamp == null;
+    }
+
+    public void setLastDequeueAttemptTimestamp(Long timestamp) {
+        this.lastDequeueAttemptTimestamp = timestamp;
+        updateLastUpdatedTimestamp();
+    }
+
+    public Long getLastDequeueAttemptTimestamp() {
+        return this.lastDequeueAttemptTimestamp;
+    }
+
+    public void setLastDequeueSuccessTimestamp(Long timestamp) {
+        this.lastDequeueSuccessTimestamp = timestamp;
+        updateLastUpdatedTimestamp();
+    }
+
+    public Long getLastDequeueSuccessTimestamp() {
+        return this.lastDequeueSuccessTimestamp;
+    }
+
+    public void setNextDequeueDueTimestamp(Long timestamp) {
+        this.nextDequeueDueTimestamp = timestamp;
+        updateLastUpdatedTimestamp();
+    }
+
+    public Long getNextDequeueDueTimestamp() {
+        return this.nextDequeueDueTimestamp;
+    }
+
+    public Long getLastUpdatedTimestamp() {
+        return lastUpdatedTimestamp;
     }
 }

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
@@ -16,7 +16,7 @@ public class DequeueStatistic implements Serializable {
         return lastDequeueAttemptTimestamp == null && lastDequeueSuccessTimestamp == null && nextDequeueDueTimestamp == null;
     }
 
-    public void setLastDequeueAttemptTimestamp(Long timestamp) {
+    public void setLastDequeueAttemptTimestamp(long timestamp) {
         this.lastDequeueAttemptTimestamp = timestamp;
         updateLastUpdatedTimestamp();
     }
@@ -25,7 +25,7 @@ public class DequeueStatistic implements Serializable {
         return this.lastDequeueAttemptTimestamp;
     }
 
-    public void setLastDequeueSuccessTimestamp(Long timestamp) {
+    public void setLastDequeueSuccessTimestamp(long timestamp) {
         this.lastDequeueSuccessTimestamp = timestamp;
         updateLastUpdatedTimestamp();
     }

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatistic.java
@@ -8,7 +8,7 @@ public class DequeueStatistic implements Serializable {
     private Long nextDequeueDueTimestamp = null;
     private Long lastUpdatedTimestamp = null;
 
-    private boolean markToDelete = false;
+    private boolean markForRemoval = false;
 
     private void updateLastUpdatedTimestamp() {
         this.lastUpdatedTimestamp = System.currentTimeMillis();
@@ -49,11 +49,12 @@ public class DequeueStatistic implements Serializable {
         return lastUpdatedTimestamp;
     }
 
-    public void setMarkToDelete() {
-        this.markToDelete = true;
+    public void setMarkedForRemoval() {
+        this.markForRemoval = true;
+        updateLastUpdatedTimestamp();
     }
 
-    public boolean isMarkToDelete() {
-        return this.markToDelete;
+    public boolean isMarkedForRemoval() {
+        return this.markForRemoval;
     }
 }

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
@@ -1,0 +1,96 @@
+package org.swisspush.redisques.util;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.SharedData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class DequeueStatisticCollector {
+    private static final Logger log = LoggerFactory.getLogger(DequeueStatisticCollector.class);
+    private final static String DEQUEUE_STATISTIC_DATA = "dequeueStatisticData";
+    private final static String DEQUEUE_STATISTIC_LOCK_PREFIX = "dequeueStatisticLock.";
+    private final SharedData sharedData;
+
+    public DequeueStatisticCollector(Vertx vertx) {
+        this.sharedData = vertx.sharedData();
+    }
+
+
+    public void setDequeueStatistic(final String queueName, final DequeueStatistic newDequeueStatistic) {
+        // To make lock works with Cluster, need set SemaphoreConfig.InitialPermits=1
+        // Ref: https://github.com/vert-x3/vertx-hazelcast/blob/master/src/main/asciidoc/index.adoc#using-an-existing-hazelcast-cluster
+        sharedData.getLock(DEQUEUE_STATISTIC_LOCK_PREFIX.concat(queueName)).onSuccess(lock ->
+                sharedData.getAsyncMap(DEQUEUE_STATISTIC_DATA, (Handler<AsyncResult<AsyncMap<String, DequeueStatistic>>>) asyncResult -> {
+                    if (asyncResult.failed()) {
+                        log.error("Failed to get dequeue statistic data map.", asyncResult.cause());
+                        lock.release();
+                    } else {
+                        AsyncMap<String, DequeueStatistic> asyncMap = asyncResult.result();
+                        if (newDequeueStatistic == null) {
+                            // remove
+                            asyncMap.remove(queueName).onComplete(event -> lock.release());
+                        } else {
+                            // add or update
+                            asyncMap.get(queueName).onSuccess(dequeueStatistic -> {
+                                if (dequeueStatistic == null) {
+                                    try {
+                                        asyncMap.put(queueName, newDequeueStatistic).onSuccess(event -> {
+                                            log.debug("dequeue statistic for queue {} added.", queueName);
+                                            lock.release();
+                                        }).onFailure(event -> {
+                                            log.debug("dequeue statistic for queue {} failed to add.", queueName);
+                                            lock.release();
+                                        });
+                                    } catch (Exception e) {
+                                        lock.release();
+                                    }
+                                    return;
+                                } else if (dequeueStatistic.getLastUpdatedTimestamp() < newDequeueStatistic.getLastUpdatedTimestamp()) {
+                                    asyncMap.put(queueName, newDequeueStatistic).onComplete(event -> {
+                                        if (event.succeeded()) {
+                                            log.debug("dequeue statistic for queue {} updated.", queueName);
+                                        } else {
+                                            log.debug("dequeue statistic for queue {} failed to update.", queueName);
+                                        }
+                                        lock.release();
+                                    });
+                                    return;
+                                } else {
+                                    log.debug("dequeue statistic for queue {} has newer data, update skipped", queueName);
+                                }
+                                lock.release();
+                            }).onFailure(throwable -> {
+                                lock.release();
+                                log.error("Failed to get dequeue statistic data for queue {}.", queueName, throwable);
+                            });
+                        }
+                    }
+                })).onFailure(throwable -> {
+            log.error("Failed to lock dequeue statistic data for queue {}.", queueName, throwable);
+        });
+    }
+
+    public Future<Map<String, DequeueStatistic>> getAllDequeueStatistics() {
+        Promise<Map<String, DequeueStatistic>> promise = Promise.promise();
+        sharedData.getAsyncMap(DEQUEUE_STATISTIC_DATA, (Handler<AsyncResult<AsyncMap<String, DequeueStatistic>>>) asyncResult -> {
+            if (asyncResult.failed()) {
+                log.error("Failed to get dequeue statistic data map.", asyncResult.cause());
+                promise.fail(asyncResult.cause());
+            } else {
+                AsyncMap<String, DequeueStatistic> asyncMap = asyncResult.result();
+                asyncMap.entries().onSuccess(promise::complete).onFailure(throwable -> {
+                    log.error("Failed to get dequeue statistic map", throwable);
+                    promise.fail(throwable);
+                });
+            }
+        });
+        return promise.future();
+    }
+}

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
@@ -48,7 +48,7 @@ public class DequeueStatisticCollector {
                                     try {
                                         asyncMap.put(queueName, dequeueStatistic).onComplete(voidAsyncResult -> {
                                             if (voidAsyncResult.failed()){
-                                                log.error("shared dequeue statistic for queue {} failed to add.", queueName);
+                                                log.error("shared dequeue statistic for queue {} failed to add.", queueName, voidAsyncResult.cause());
                                             } else {
                                                 log.debug("shared dequeue statistic for queue {} added.", queueName);
                                             }
@@ -63,7 +63,7 @@ public class DequeueStatisticCollector {
                                         // delete
                                         asyncMap.remove(queueName).onComplete(removeAsyncResult -> {
                                             if (removeAsyncResult.failed()){
-                                                log.error("failed to removed shared dequeue statistic for queue {}.", queueName);
+                                                log.error("failed to removed shared dequeue statistic for queue {}.", queueName, removeAsyncResult.cause());
                                             } else {
                                                 log.debug("shared dequeue statistic for queue {} removed.", queueName);
                                             }
@@ -73,7 +73,7 @@ public class DequeueStatisticCollector {
                                         // update
                                         asyncMap.put(queueName, dequeueStatistic).onComplete(event -> {
                                             if (event.failed()) {
-                                                log.error("shared dequeue statistic for queue {} failed to update.", queueName);
+                                                log.error("shared dequeue statistic for queue {} failed to update.", queueName, event.cause());
                                             } else {
                                                 log.debug("shared dequeue statistic for queue {} updated.", queueName);
                                             }

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
@@ -53,7 +53,7 @@ public class DequeueStatisticCollector {
                                 asyncMap.remove(queueName).onComplete(dequeueStatisticAsyncResult -> {
                                     log.debug("dequeue statistic for queue {} removed.", queueName);
                                     lock.release();
-                                })
+                                });
                             } else {
                                 // update
                                 asyncMap.put(queueName, dequeueStatistic).onComplete(event -> {

--- a/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/DequeueStatisticCollector.java
@@ -6,6 +6,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Lock;
 import io.vertx.core.shareddata.SharedData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +24,11 @@ public class DequeueStatisticCollector {
     }
 
     public void setDequeueStatistic(final String queueName, final DequeueStatistic dequeueStatistic) {
-        sharedData.getLock(DEQUEUE_STATISTIC_LOCK_PREFIX.concat(queueName)).onSuccess(lock ->
+        sharedData.getLock(DEQUEUE_STATISTIC_LOCK_PREFIX.concat(queueName)).onComplete(lockAsyncResult -> {
+            if (lockAsyncResult.failed()) {
+                log.error("Failed to lock dequeue statistic data for queue {}.", queueName, lockAsyncResult.cause());
+            } else {
+                final Lock lock = lockAsyncResult.result();
                 sharedData.getAsyncMap(DEQUEUE_STATISTIC_DATA, (Handler<AsyncResult<AsyncMap<String, DequeueStatistic>>>) asyncResult -> {
                     if (asyncResult.failed()) {
                         log.error("Failed to get shared dequeue statistic data map.", asyncResult.cause());
@@ -33,50 +38,57 @@ public class DequeueStatisticCollector {
                     AsyncMap<String, DequeueStatistic> asyncMap = asyncResult.result();
                     asyncMap.size().onComplete(mapSizeResult -> {
                         log.debug("shared dequeue statistic map size: {}", mapSizeResult.result());
-                        asyncMap.get(queueName).onSuccess(sharedDequeueStatistic -> {
-                            if (sharedDequeueStatistic == null) {
-                                try {
-                                    asyncMap.put(queueName, dequeueStatistic).onSuccess(event -> {
-                                        log.debug("shared dequeue statistic for queue {} added.", queueName);
+                        asyncMap.get(queueName).onComplete(dequeueStatisticAsyncResult -> {
+                            if (dequeueStatisticAsyncResult.failed()) {
+                                lock.release();
+                                log.error("Failed to get shared dequeue statistic data for queue {}.", queueName, dequeueStatisticAsyncResult.cause());
+                            } else {
+                                final DequeueStatistic sharedDequeueStatistic = dequeueStatisticAsyncResult.result();
+                                if (sharedDequeueStatistic == null) {
+                                    try {
+                                        asyncMap.put(queueName, dequeueStatistic).onComplete(voidAsyncResult -> {
+                                            if (voidAsyncResult.failed()){
+                                                log.error("shared dequeue statistic for queue {} failed to add.", queueName);
+                                            } else {
+                                                log.debug("shared dequeue statistic for queue {} added.", queueName);
+                                            }
+                                            lock.release();
+                                        });
+                                    } catch (Exception exception) {
+                                        log.error("Failed to put shared dequeue statistic for queue {}.", queueName, exception);
                                         lock.release();
-                                    }).onFailure(event -> {
-                                        log.debug("shared dequeue statistic for queue {} failed to add.", queueName);
-                                        lock.release();
-                                    });
-                                } catch (Exception exception) {
-                                    log.error("Failed to put shared dequeue statistic for queue {}.", queueName, exception);
+                                    }
+                                } else if (sharedDequeueStatistic.getLastUpdatedTimestamp() < dequeueStatistic.getLastUpdatedTimestamp()) {
+                                    if (dequeueStatistic.isMarkedForRemoval()) {
+                                        // delete
+                                        asyncMap.remove(queueName).onComplete(removeAsyncResult -> {
+                                            if (removeAsyncResult.failed()){
+                                                log.error("failed to removed shared dequeue statistic for queue {}.", queueName);
+                                            } else {
+                                                log.debug("shared dequeue statistic for queue {} removed.", queueName);
+                                            }
+                                            lock.release();
+                                        });
+                                    } else {
+                                        // update
+                                        asyncMap.put(queueName, dequeueStatistic).onComplete(event -> {
+                                            if (event.failed()) {
+                                                log.error("shared dequeue statistic for queue {} failed to update.", queueName);
+                                            } else {
+                                                log.debug("shared dequeue statistic for queue {} updated.", queueName);
+                                            }
+                                            lock.release();
+                                        });
+                                    }
+                                } else {
+                                    log.debug("shared dequeue statistic for queue {} has newer data, update skipped", queueName);
                                     lock.release();
                                 }
-                            } else if (sharedDequeueStatistic.getLastUpdatedTimestamp() < dequeueStatistic.getLastUpdatedTimestamp()) {
-                                if (dequeueStatistic.isMarkedForRemoval()) {
-                                    // delete
-                                    asyncMap.remove(queueName).onComplete(dequeueStatisticAsyncResult -> {
-                                        log.debug("shared dequeue statistic for queue {} removed.", queueName);
-                                        lock.release();
-                                    });
-                                } else {
-                                    // update
-                                    asyncMap.put(queueName, dequeueStatistic).onComplete(event -> {
-                                        if (event.succeeded()) {
-                                            log.debug("shared dequeue statistic for queue {} updated.", queueName);
-                                        } else {
-                                            log.debug("shared dequeue statistic for queue {} failed to update.", queueName);
-                                        }
-                                        lock.release();
-                                    });
-                                }
-                            } else {
-                                log.debug("shared dequeue statistic for queue {} has newer data, update skipped", queueName);
-                                lock.release();
                             }
-                        }).onFailure(throwable -> {
-                            lock.release();
-                            log.error("Failed to get shared dequeue statistic data for queue {}.", queueName, throwable);
                         });
-
                     });
-                })).onFailure(throwable -> {
-            log.error("Failed to lock dequeue statistic data for queue {}.", queueName, throwable);
+                });
+            }
         });
     }
 

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -48,12 +48,10 @@ public class QueueStatisticsCollector {
     private final static String QUEUE_FAILURES = "failures";
     private final static String QUEUE_BACKPRESSURE = "backpressureTime";
     private final static String QUEUE_SLOWDOWNTIME = "slowdownTime";
-    private final static String QUEUE_DEQUEUE_STATISTIC = "dequeueStatistic";
 
     private final Map<String, AtomicLong> queueFailureCount = new HashMap<>();
     private final Map<String, Long> queueBackpressureTime = new HashMap<>();
     private final Map<String, Long> queueSlowDownTime = new HashMap<>();
-    private final Map<String, DequeueStatistic> dequeueStatistics = new HashMap<>();
     private final ConcurrentMap<String, AtomicLong> queueMessageSpeedCtr = new ConcurrentHashMap<>();
     private volatile Map<String, Long> queueMessageSpeed = new HashMap<>();
     private final RedisProvider redisProvider;
@@ -292,30 +290,6 @@ public class QueueStatisticsCollector {
     }
 
     /**
-     * Sets the {@link DequeueStatistic} for the given queue. Note that this is done in memory
-     * but as well persisted in redis.
-     *
-     * @param queueName The name of the queue for which the stats must be set.
-     * @param dequeueStatistic The {@link DequeueStatistic}
-     */
-    public void setDequeueStatistic(String queueName, DequeueStatistic dequeueStatistic) {
-        if (!dequeueStatistic.isEmpty()) {
-            dequeueStatistics.put(queueName, dequeueStatistic);
-            updateStatisticsInRedis(queueName);
-        }
-    }
-
-    /**
-     * Retrieves the current {@link DequeueStatistic} of the given queue we have in memory for this redisques instance.
-     * <p>
-     * @param queueName The queue name for which we want to retrieve the current failure count
-     * @return The last {@link DequeueStatistic}
-     */
-    private DequeueStatistic getDequeueStatistic(String queueName) {
-        return dequeueStatistics.getOrDefault(queueName, new DequeueStatistic());
-    }
-
-    /**
      * Write all the collected failure statistics for the given Queue to
      * redis for later usage if somebody requests the queue statistics.
      * If there are no valid useful data available eg. all 0, the corresponding
@@ -325,14 +299,12 @@ public class QueueStatisticsCollector {
         long failures = getQueueFailureCount(queueName);
         long slowDownTime = getQueueSlowDownTime(queueName);
         long backpressureTime = getQueueBackPressureTime(queueName);
-        DequeueStatistic dequeueStatistic = getDequeueStatistic(queueName);
-        if (failures > 0 || slowDownTime > 0 || backpressureTime > 0 || !dequeueStatistic.isEmpty()) {
+        if (failures > 0 || slowDownTime > 0 || backpressureTime > 0) {
             JsonObject obj = new JsonObject();
             obj.put(QUEUENAME, queueName);
             obj.put(QUEUE_FAILURES, failures);
             obj.put(QUEUE_SLOWDOWNTIME, slowDownTime);
             obj.put(QUEUE_BACKPRESSURE, backpressureTime);
-            obj.put(QUEUE_DEQUEUE_STATISTIC, JsonObject.mapFrom(dequeueStatistic));
             redisProvider.redis()
                     .onSuccess(redisAPI -> {
                         redisAPI.hset(List.of(STATSKEY, queueName, obj.toString()), ev -> {
@@ -362,7 +334,6 @@ public class QueueStatisticsCollector {
         private long backpressureTime;
         private long slowdownTime;
         private long speed;
-        private JsonObject dequeueStatistic;
 
         QueueStatistic(String queueName) {
             this.queueName = queueName;
@@ -408,14 +379,6 @@ public class QueueStatisticsCollector {
             this.speed = 0;
         }
 
-        void setDequeueStatistic(DequeueStatistic dequeueStatistic) {
-            if (dequeueStatistic != null && !dequeueStatistic.isEmpty()) {
-                this.dequeueStatistic = JsonObject.mapFrom(dequeueStatistic);
-                return;
-            }
-            this.dequeueStatistic = JsonObject.mapFrom(new DequeueStatistic());
-        }
-
         JsonObject getAsJsonObject() {
             return new JsonObject()
                     .put(MONITOR_QUEUE_NAME, queueName)
@@ -423,8 +386,7 @@ public class QueueStatisticsCollector {
                     .put(STATISTIC_QUEUE_FAILURES, failures)
                     .put(STATISTIC_QUEUE_BACKPRESSURE, backpressureTime)
                     .put(STATISTIC_QUEUE_SLOWDOWN, slowdownTime)
-                    .put(STATISTIC_QUEUE_SPEED, speed)
-                    .put(QUEUE_DEQUEUE_STATISTIC, dequeueStatistic);
+                    .put(STATISTIC_QUEUE_SPEED, speed);
         }
     }
 
@@ -584,9 +546,6 @@ public class QueueStatisticsCollector {
                 queueStatistic.setFailures(jObj.getLong(QUEUE_FAILURES, 0L));
                 queueStatistic.setBackpressureTime(jObj.getLong(QUEUE_BACKPRESSURE, 0L));
                 queueStatistic.setSlowdownTime(jObj.getLong(QUEUE_SLOWDOWNTIME, 0L));
-                if (jObj.containsKey(QUEUE_DEQUEUE_STATISTIC)) {
-                    queueStatistic.setDequeueStatistic(jObj.getJsonObject(QUEUE_DEQUEUE_STATISTIC).mapTo(DequeueStatistic.class));
-                }
             }
         }
         // build the final resulting statistics list from the former merged queue


### PR DESCRIPTION
With this PR we fix an issue where we got inconsistent stats due to the distribution of queue processing to multiple verticles. The stats are no shared across the verticles using https://vertx.io/docs/vertx-core/java/#_using_the_shareddata_api 