### PR TITLE
Apply backpressure in misc places to prevent resource exhaustion issues

### DIFF
--- a/src/main/java/org/swisspush/redisques/QueueStatsService.java
+++ b/src/main/java/org/swisspush/redisques/QueueStatsService.java
@@ -68,7 +68,7 @@ public class QueueStatsService {
 
     public <CTX> void getQueueStats(CTX mCtx, GetQueueStatsMentor<CTX> mentor) {
         if (!incomingRequestQuota.tryAcquire()) {
-            var ex = new RuntimeException("Server too busy to handle yet-another-queue-stats-request now");
+            var ex = new NoStacktraceException("Server too busy to handle yet-another-queue-stats-request now (error_bG8CAJJ3AgCKMwIAPBUC)");
             vertx.runOnContext(v -> mentor.onError(ex, mCtx));
             return;
         }

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -20,6 +20,7 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.swisspush.redisques.action.QueueAction;
+import org.swisspush.redisques.exception.NoStacktraceException;
 import org.swisspush.redisques.handler.RedisquesHttpRequestHandler;
 import org.swisspush.redisques.performance.UpperBoundParallel;
 import org.swisspush.redisques.scheduling.PeriodicSkipScheduler;
@@ -546,10 +547,10 @@ public class RedisQues extends AbstractVerticle {
                                 log.debug("RedisQues Periodic consumer refresh for active queue {}", queue);
                                 refreshRegistration(queue, ev -> {
                                     if (ev.failed())
-                                        log.warn("TODO error handling", new Exception(ev.cause()));
+                                        log.warn("TODO_1WoCAD1bAgBRBwIA9yQC error handling", ev.cause());
                                     updateTimestamp(queue, updateTimestampEv -> {
-                                        if (updateTimestampEv.failed()) log.warn("TODO error handling",
-                                                new RuntimeException(updateTimestampEv.cause()));
+                                        if (updateTimestampEv.failed()) log.warn(
+                                                "TODO_mWoCAARJAgDTXAIASwUC error handling", updateTimestampEv.cause());
                                         onDone.run();
                                     });
                                 });
@@ -557,7 +558,7 @@ public class RedisQues extends AbstractVerticle {
                                 log.debug("RedisQues Removing queue {} from the list", queue);
                                 myQueues.remove(queue);
                                 queueStatisticsCollector.resetQueueFailureStatistics(queue, (Throwable ex, Void v) -> {
-                                    if (ex != null) log.warn("TODO error handling", new RuntimeException(ex));
+                                    if (ex != null) log.warn("TODO_RGsCAA4CAgDdWAIAVRMC error handling", ex);
                                     onDone.run();
                                 });
                             }
@@ -592,7 +593,7 @@ public class RedisQues extends AbstractVerticle {
             // handle system operations
             switch (queueOperation) {
                 case check:
-                    checkQueues().onFailure(ex -> log.error("TODO error handling", new RuntimeException(ex)));
+                    checkQueues().onFailure(ex -> log.warn("TODO_e2UCAGlXAgBAZQIAlBcC error handling", ex));
                     return;
                 case reset:
                     resetConsumers();
@@ -643,7 +644,7 @@ public class RedisQues extends AbstractVerticle {
                 log.info("periodic queue check is triggered now");
                 return checkQueues();
             }).onFailure(ex -> {
-                log.error("TODO error handling", ex);
+                log.warn("TODO_WmYCAIxGAgB0aAIA4yoC error handling", ex);
             });
         });
     }
@@ -664,10 +665,10 @@ public class RedisQues extends AbstractVerticle {
 
     private void gracefulStop(final Handler<Void> doneHandler) {
         consumersMessageConsumer.unregister(event -> uidMessageConsumer.unregister(unregisterEvent -> {
-            if( event.failed() ) log.warn("TODO error handling", new Exception(event.cause()));
+            if( event.failed() ) log.warn("TODO_FWsCAAE0AgCPRQIA8QgC error handling", event.cause());
             unregisterConsumers(false).onComplete(unregisterConsumersEvent -> {
                 if( unregisterEvent.failed() )
-                    log.warn("TODO error handling", new Exception(unregisterEvent.cause()));
+                    log.warn("TODO_82sCAAczAgCQVgIA6E0C error handling", unregisterEvent.cause());
                 stoppedHandler = doneHandler;
                 if (myQueues.keySet().isEmpty()) {
                     doneHandler.handle(null);
@@ -687,7 +688,7 @@ public class RedisQues extends AbstractVerticle {
             if (force || entry.getValue() == QueueState.READY) {
                 log.trace("RedisQues unregister consumers queue: {}", queue);
                 refreshRegistration(queue, event -> {
-                    if( event.failed() ) log.warn("TODO error handling", new Exception(event.cause()));
+                    if( event.failed() ) log.warn("TODO_12sCABtNAgAqKAIAWg0C error handling", event.cause());
                     // Make sure that I am still the registered consumer
                     String consumerKey = consumersPrefix + queue;
                     log.trace("RedisQues unregister consumers get: {}", consumerKey);
@@ -713,7 +714,7 @@ public class RedisQues extends AbstractVerticle {
             }
         }
         CompositeFuture.all(futureList).onComplete(ev -> {
-            if( ev.failed() ) log.warn("TODO error handling", new Exception(ev.cause()));
+            if( ev.failed() ) log.warn("TODO_m2sCABpzAgCHbQIA5TYC error handling", ev.cause());
             result.complete();
         });
         return result.future();
@@ -786,7 +787,7 @@ public class RedisQues extends AbstractVerticle {
                                 log.debug("RedisQues Starting to consume queue {}", queueName);
                                 readQueue(queueName).onComplete(readQueueEvent -> {
                                     if( readQueueEvent.failed() )
-                                        log.warn("TODO error handling", new Exception(readQueueEvent.cause()));
+                                        log.warn("TODO_aWwCACYIAgCpZwIA8RgC error handling", readQueueEvent.cause());
                                     promise.complete();
                                 });
                             } else {
@@ -799,7 +800,7 @@ public class RedisQues extends AbstractVerticle {
                             myQueues.remove(queueName);
                             notifyConsumer(queueName).onComplete(notifyConsumerEvent -> {
                                 if( notifyConsumerEvent.failed() )
-                                    log.warn("TODO error handling", notifyConsumerEvent.cause());
+                                    log.warn("TODO_Q2wCAHFYAgCgRQIA8yoC error handling", notifyConsumerEvent.cause());
                                 promise.complete();
                             });
                         }
@@ -839,7 +840,7 @@ public class RedisQues extends AbstractVerticle {
 
         isQueueLocked(queueName).onComplete(lockAnswer -> {
             if( lockAnswer.failed() )
-                throw new UnsupportedOperationException("TODO error handling " + queueName, lockAnswer.cause());
+                throw new NoStacktraceException("TODO_o2wCACFRAgAAKAIAMUUC error handling " + queueName, lockAnswer.cause());
             boolean locked = lockAnswer.result();
             if (!locked) {
                 redisProvider.redis().onSuccess(redisAPI -> redisAPI.lindex(queueKey, "0", answer -> {
@@ -877,12 +878,12 @@ public class RedisQues extends AbstractVerticle {
                                             if (answer1.succeeded() && answer1.result() != null && answer1.result().toInteger() > 0) {
                                                 notifyConsumer(queueName).onComplete(event1 -> {
                                                     if( event1.failed() )
-                                                        log.warn("TODO error handling", new Exception(event1.cause()));
+                                                        log.warn("TODO_d20CAD8wAgCbZQIAvSgC error handling", event1.cause());
                                                     promise.complete();
                                                 });
                                             } else {
                                                 if( answer1.failed() )
-                                                    log.warn("TODO error handling", new Exception(answer1.cause()));
+                                                    log.warn("TODO_bm0CAEFuAgBcUAIAfQ8C error handling", answer1.cause());
                                                 promise.complete();
                                             }
                                         });
@@ -892,7 +893,7 @@ public class RedisQues extends AbstractVerticle {
                                     if (stoppedHandler != null) {
                                         unregisterConsumers(false).onComplete(event -> {
                                             if( event.failed() )
-                                                log.warn("TODO error handling", new Exception(event.cause()));
+                                                log.warn("TODO_GW0CAMUlAgDcJgIAzncC error handling", event.cause());
                                             if (myQueues.isEmpty()) {
                                                 stoppedHandler.handle(null);
                                             }
@@ -951,7 +952,7 @@ public class RedisQues extends AbstractVerticle {
                 log.debug("RedisQues re-notify the consumer of queue '{}' at {}", queueName, new Date(System.currentTimeMillis()));
             }
             notifyConsumer(queueName).onComplete(event -> {
-                if( event.failed() ) log.warn("TODO error handling", new Exception(event.cause()));
+                if( event.failed() ) log.warn("TODO_6m0CAExTAgCYSgIAnxkC error handling", event.cause());
                 // reset the queue state to be consumed by {@link RedisQues#consume(String)}
                 myQueues.put(queueName, QueueState.READY);
             });
@@ -1099,7 +1100,6 @@ public class RedisQues extends AbstractVerticle {
             assert ctx.iter == null;
             ctx.counter = new AtomicInteger(queues.size());
             ctx.iter = queues.iterator();
-            // MUST pre-initialize ALL futures, so that our 'Future.all()' call knows
             log.trace("RedisQues update queues: {}", ctx.counter);
             var p = Promise.<Void>promise();
             upperBoundParallel.request(checkQueueRequestsQuota, null, new UpperBoundParallel.Mentor<Void>() {
@@ -1114,11 +1114,11 @@ public class RedisQues extends AbstractVerticle {
                             // Make sure its TTL is correctly set (replaces the previous orphan detection mechanism).
                             refreshRegistration(queueName, refreshRegistrationEvent -> {
                                 if( refreshRegistrationEvent.failed() )
-                                    log.warn("TODO error handling", new Exception(refreshRegistrationEvent.cause()));
+                                    log.warn("TODO_V2kCANpoAgAqHwIA3TIC error handling", refreshRegistrationEvent.cause());
                                 // And trigger its consumer.
                                 notifyConsumer(queueName).onComplete(notifyConsumerEvent -> {
                                     if( notifyConsumerEvent.failed() )
-                                        log.warn("TODO error handling", new Exception(notifyConsumerEvent.cause()));
+                                        log.warn("TODO_3WkCACRTAgDbdwIAAEwC error handling", notifyConsumerEvent.cause());
                                     onDone.accept(null, null);
                                 });
                             });
@@ -1141,7 +1141,7 @@ public class RedisQues extends AbstractVerticle {
                                     if (ctx.counter.decrementAndGet() == 0) {
                                         removeOldQueues(ctx.limit).onComplete(removeOldQueuesEvent -> {
                                             if (removeOldQueuesEvent.failed())
-                                                log.warn("TODO error handling", new Exception(removeOldQueuesEvent.cause()));
+                                                log.warn("TODO_i2kCAChDAgDrbAIAIWcC error handling", removeOldQueuesEvent.cause());
                                             refreshRegHandler.handle(null);
                                         });
                                     } else {
@@ -1162,7 +1162,7 @@ public class RedisQues extends AbstractVerticle {
                                 if (ctx.counter.decrementAndGet() == 0) {
                                     removeOldQueues(ctx.limit).onComplete(removeOldQueuesEvent -> {
                                         if( removeOldQueuesEvent.failed() )
-                                            log.warn("TODO error handling", new Exception(removeOldQueuesEvent.cause()));
+                                            log.warn("TODO_aGoCAOtOAgAnbQIA4zQC error handling", removeOldQueuesEvent.cause());
                                         queueStatisticsCollector.resetQueueFailureStatistics(queueName, onDone);
                                     });
                                 } else {
@@ -1174,7 +1174,7 @@ public class RedisQues extends AbstractVerticle {
                     return ctx.iter.hasNext();
                 }
                 @Override public boolean onError(Throwable ex, Void ctx_) {
-                    log.warn("TODO error handling", new RuntimeException(ex));
+                    log.warn("TODO_LWoCABp8AgAiIQIAlC4C error handling", ex);
                     return true; // true, keep going with other queues.
                 }
                 @Override public void onDone(Void ctx_) {
@@ -1208,7 +1208,7 @@ public class RedisQues extends AbstractVerticle {
         redisProvider.redis()
                 .onSuccess(redisAPI -> {
                     redisAPI.zremrangebyscore(queuesKey, "-inf", String.valueOf(limit), event -> {
-                        if( event.failed() ) log.warn("TODO error handling", event.cause());
+                        if( event.failed() ) log.warn("TODO_92oCAP5SAgCcOgIAMW8C error handling", event.cause());
                         promise.complete();
                     });
                 })

--- a/src/main/java/org/swisspush/redisques/action/GetQueueItemsCountAction.java
+++ b/src/main/java/org/swisspush/redisques/action/GetQueueItemsCountAction.java
@@ -31,6 +31,7 @@ public class GetQueueItemsCountAction extends AbstractQueueAction {
 
     @Override
     public void execute(Message<JsonObject> event) {
+        /* TODO this seems the handler that is timing out. */
         String queue = event.body().getJsonObject(PAYLOAD).getString(QUEUENAME);
         var p = redisProvider.redis();
         p.onSuccess(redisAPI -> redisAPI.llen(queuesPrefix + queue, new GetQueueItemsCountHandler(event)));

--- a/src/main/java/org/swisspush/redisques/action/GetQueueItemsCountAction.java
+++ b/src/main/java/org/swisspush/redisques/action/GetQueueItemsCountAction.java
@@ -31,7 +31,6 @@ public class GetQueueItemsCountAction extends AbstractQueueAction {
 
     @Override
     public void execute(Message<JsonObject> event) {
-        /* TODO this seems the handler that is timing out. */
         String queue = event.body().getJsonObject(PAYLOAD).getString(QUEUENAME);
         var p = redisProvider.redis();
         p.onSuccess(redisAPI -> redisAPI.llen(queuesPrefix + queue, new GetQueueItemsCountHandler(event)));

--- a/src/main/java/org/swisspush/redisques/exception/ExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/ExceptionFactory.java
@@ -1,0 +1,38 @@
+package org.swisspush.redisques.exception;
+
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+
+
+/**
+ * Applies dependency inversion for exception instantiation.
+ *
+ * This class did arise because we had different use cases in different
+ * applications. One of them has the need to perform fine-grained error
+ * reporting. Whereas in the other application this led to performance issues.
+ * So now through this abstraction, both applications can choose the behavior
+ * they need.
+ *
+ * If dependency-injection gets applied properly, an app can even provide its
+ * custom implementation to fine-tune the exact behavior even further.
+ */
+public interface ExceptionFactory {
+
+    public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message);
+
+
+    /**
+     * See {@link ThriftyExceptionFactory}.
+     */
+    public static ExceptionFactory newThriftyExceptionFactory() {
+        return new ThriftyExceptionFactory();
+    }
+
+    /**
+     * See {@link WastefulExceptionFactory}.
+     */
+    public static ExceptionFactory newWastefulExceptionFactory() {
+        return new WastefulExceptionFactory();
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/exception/ExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/ExceptionFactory.java
@@ -18,6 +18,8 @@ import io.vertx.core.eventbus.ReplyFailure;
  */
 public interface ExceptionFactory {
 
+    public Exception newException(String message, Throwable cause);
+
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message);
 
 

--- a/src/main/java/org/swisspush/redisques/exception/NoStackReplyException.java
+++ b/src/main/java/org/swisspush/redisques/exception/NoStackReplyException.java
@@ -1,0 +1,30 @@
+package org.swisspush.redisques.exception;
+
+import io.vertx.core.eventbus.ReplyFailure;
+
+/**
+ * There was once a fix in vertx for this (https://github.com/eclipse-vertx/vert.x/issues/4840)
+ * but for whatever reason in our case we still see stack-trace recordings. Passing
+ * this subclass to {@link io.vertx.core.eventbus.Message#reply(Object)} seems to
+ * do the trick.
+ */
+public class NoStackReplyException extends io.vertx.core.eventbus.ReplyException {
+
+    public NoStackReplyException(ReplyFailure failureType, int failureCode, String message) {
+        super(failureType, failureCode, message);
+    }
+
+    public NoStackReplyException(ReplyFailure failureType, String message) {
+        this(failureType, -1, message);
+    }
+
+    public NoStackReplyException(ReplyFailure failureType) {
+        this(failureType, -1, null);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/exception/NoStacktraceException.java
+++ b/src/main/java/org/swisspush/redisques/exception/NoStacktraceException.java
@@ -1,0 +1,28 @@
+package org.swisspush.redisques.exception;
+
+/**
+ * Basically same as in vertx, But adding the forgotten contructors.
+ */
+public class NoStacktraceException extends RuntimeException {
+
+    public NoStacktraceException() {
+    }
+
+    public NoStacktraceException(String message) {
+        super(message);
+    }
+
+    public NoStacktraceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoStacktraceException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/exception/ThriftyExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/ThriftyExceptionFactory.java
@@ -1,0 +1,20 @@
+package org.swisspush.redisques.exception;
+
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+
+/**
+ * Trades maintainability for speed. For example prefers lightweight
+ * exceptions without stacktrace recording. It may even decide to drop 'cause'
+ * and 'suppressed' exceptions. If an app needs more error details it should use
+ * {@link WastefulExceptionFactory}. If none of those fits the apps needs, it
+ * can provide its own implementation.
+ */
+class ThriftyExceptionFactory implements ExceptionFactory {
+
+    @Override
+    public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
+        return new NoStackReplyException(failureType, failureCode, message);
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/exception/ThriftyExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/ThriftyExceptionFactory.java
@@ -12,6 +12,9 @@ import io.vertx.core.eventbus.ReplyFailure;
  */
 class ThriftyExceptionFactory implements ExceptionFactory {
 
+    ThriftyExceptionFactory() {
+    }
+
     @Override
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
         return new NoStackReplyException(failureType, failureCode, message);

--- a/src/main/java/org/swisspush/redisques/exception/ThriftyExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/ThriftyExceptionFactory.java
@@ -15,6 +15,10 @@ class ThriftyExceptionFactory implements ExceptionFactory {
     ThriftyExceptionFactory() {
     }
 
+    public Exception newException(String message, Throwable cause) {
+        return new NoStacktraceException(message, cause);
+    }
+
     @Override
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
         return new NoStackReplyException(failureType, failureCode, message);

--- a/src/main/java/org/swisspush/redisques/exception/WastefulExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/WastefulExceptionFactory.java
@@ -13,6 +13,9 @@ import io.vertx.core.eventbus.ReplyFailure;
  */
 class WastefulExceptionFactory implements ExceptionFactory {
 
+    WastefulExceptionFactory() {
+    }
+
     @Override
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
         return new ReplyException(failureType, failureCode, message);

--- a/src/main/java/org/swisspush/redisques/exception/WastefulExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/WastefulExceptionFactory.java
@@ -16,6 +16,10 @@ class WastefulExceptionFactory implements ExceptionFactory {
     WastefulExceptionFactory() {
     }
 
+    public Exception newException(String message, Throwable cause) {
+        return new Exception(message, cause);
+    }
+
     @Override
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
         return new ReplyException(failureType, failureCode, message);

--- a/src/main/java/org/swisspush/redisques/exception/WastefulExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/WastefulExceptionFactory.java
@@ -1,0 +1,21 @@
+package org.swisspush.redisques.exception;
+
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+
+/**
+ * Trades speed for maintainability. For example invests more resources like
+ * recording stack traces (which likely provocates more logs) to get easier
+ * to debug error messages and better hints of what is happening. It also
+ * keeps details like 'causes' and 'suppressed' exceptions. If an app needs
+ * more error details it should use {@link WastefulExceptionFactory}. If none
+ * of those fits the apps needs, it can provide its own implementation.
+ */
+class WastefulExceptionFactory implements ExceptionFactory {
+
+    @Override
+    public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
+        return new ReplyException(failureType, failureCode, message);
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -5,7 +5,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Command;
@@ -65,7 +67,10 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
 
     @Override
     public void handle(AsyncResult<Response> handleQueues) {
-        if (true) throw new NoStacktraceException(/*TODO*/"not impl yet aoqör5hgjuaöoiwetrjaöelk");
+        if (redisRequestQuota.availablePermits() <= 0) {
+            event.fail(507, "Server too busy. Rejecting this GetQueuesItemsCount request");
+            return;
+        }
         if (!handleQueues.succeeded()) {
             log.warn("Concealed error", new Exception(handleQueues.cause()));
             event.reply(new JsonObject().put(STATUS, ERROR));

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -132,14 +132,15 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
                 }
                 var obj = new JsonObject().put(STATUS, OK).put(QUEUES, result);
                 long jsonCreateDurationMs = currentTimeMillis() - beginEpchMs;
-                log.info("Creating JSON with {} entries took {}ms", ctx.queueLengths.length, jsonCreateDurationMs);
+                log.info("Creating JSON with {} entries did block this tread for {}ms",
+                        ctx.queueLengths.length, jsonCreateDurationMs);
                 workerPromise.complete(obj);
             }, false);
         }).onSuccess((JsonObject json) -> {
             log.trace("call event.reply(json)");
             event.reply(json);
         }).onFailure(ex -> {
-            log.warn("Redis: Failed to get queue length.", new Exception(ex));
+            log.warn("Redis: Failed to get queue length (error_c3gCAEFrAgChbAIAdhwC)", ex);
             event.reply(new JsonObject().put(STATUS, ERROR));
         });
     }

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -16,6 +16,7 @@ import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.swisspush.redisques.exception.NoStackReplyException;
 import org.swisspush.redisques.exception.NoStacktraceException;
 import org.swisspush.redisques.performance.UpperBoundParallel;
 import org.swisspush.redisques.util.HandlerUtil;
@@ -85,7 +86,7 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
             return;
         }
         if (redisRequestQuota.availablePermits() <= 0) {
-            event.fail(507, "Server too busy. Rejecting this GetQueuesItemsCount request");
+            event.reply(new NoStackReplyException(ReplyFailure.RECIPIENT_FAILURE, 507, "Server too busy. Rejecting this GetQueuesItemsCount request"));
             return;
         }
         redisProvider.connection().compose((Redis redis_) -> {

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -1,103 +1,146 @@
 package org.swisspush.redisques.handler;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.Request;
-import io.vertx.redis.client.impl.RequestImpl;
-import io.vertx.redis.client.impl.types.NumberType;
+import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.vertx.redis.client.Response;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
+import org.swisspush.redisques.exception.NoStacktraceException;
+import org.swisspush.redisques.performance.UpperBoundParallel;
 import org.swisspush.redisques.util.HandlerUtil;
 import org.swisspush.redisques.util.RedisProvider;
-import org.swisspush.redisques.util.RedisquesAPI;
 
-import static org.swisspush.redisques.util.RedisquesAPI.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Semaphore;
+import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
+
+import static java.lang.System.currentTimeMillis;
+import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
+import static org.swisspush.redisques.util.RedisquesAPI.MONITOR_QUEUE_NAME;
+import static org.swisspush.redisques.util.RedisquesAPI.MONITOR_QUEUE_SIZE;
+import static org.swisspush.redisques.util.RedisquesAPI.OK;
+import static org.swisspush.redisques.util.RedisquesAPI.QUEUES;
+import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
 
 public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>> {
 
     private final Logger log = LoggerFactory.getLogger(GetQueuesItemsCountHandler.class);
 
+    private final Vertx vertx;
     private final Message<JsonObject> event;
     private final Optional<Pattern> filterPattern;
     private final String queuesPrefix;
     private final RedisProvider redisProvider;
+    private final UpperBoundParallel upperBoundParallel;
+    private final Semaphore redisRequestQuota;
 
     public GetQueuesItemsCountHandler(
+            Vertx vertx,
             Message<JsonObject> event,
             Optional<Pattern> filterPattern,
             String queuesPrefix,
-            RedisProvider redisProvider
+            RedisProvider redisProvider,
+            Semaphore redisRequestQuota
     ) {
+        this.vertx = vertx;
         this.event = event;
         this.filterPattern = filterPattern;
         this.queuesPrefix = queuesPrefix;
         this.redisProvider = redisProvider;
+        this.upperBoundParallel = new UpperBoundParallel(vertx);
+        this.redisRequestQuota = redisRequestQuota;
     }
 
     @Override
     public void handle(AsyncResult<Response> handleQueues) {
-        if (handleQueues.succeeded()) {
-            List<String> queues = HandlerUtil.filterByPattern(handleQueues.result(),
-                filterPattern);
-            if (queues.isEmpty()) {
-                log.debug("Queue count evaluation with empty queues");
-                event.reply(new JsonObject().put(STATUS, OK).put(QUEUES, new JsonArray()));
-                return;
-            }
-
-            redisProvider.connection().onSuccess(conn -> {
-                List<Future> responses = queues.stream()
-                        .map(queue -> conn.send(Request.cmd(Command.LLEN, queuesPrefix + queue)))
-                        .collect(Collectors.toList());
-                CompositeFuture.all(responses).onFailure(ex -> {
-                    log.error("Unexpected queue length result", new Exception(ex));
-                    event.reply(new JsonObject().put(STATUS, ERROR));
-                }).onSuccess(compositeFuture -> {
-                    List<NumberType> queueLengthList = compositeFuture.list();
-                    if (queueLengthList == null) {
-                        log.error("Unexpected queue length result null",
-                                new Exception(compositeFuture.cause()));
-                        event.reply(new JsonObject().put(STATUS, ERROR));
-                        return;
-                    }
-                    if (queueLengthList.size() != queues.size()) {
-                        log.error("Unexpected queue length result with unequal size {} : {}",
-                                queues.size(), queueLengthList.size());
-                        event.reply(new JsonObject().put(STATUS, ERROR));
-                        return;
-                    }
-                    JsonArray result = new JsonArray();
-                    for (int i = 0; i < queues.size(); i++) {
-                        String queueName = queues.get(i);
-                        result.add(new JsonObject()
-                                .put(MONITOR_QUEUE_NAME, queueName)
-                                .put(MONITOR_QUEUE_SIZE, queueLengthList.get(i).toLong()));
-                    }
-                    event.reply(new JsonObject().put(RedisquesAPI.STATUS, RedisquesAPI.OK)
-                            .put(QUEUES, result));
-                });
-            }).onFailure(ex -> {
-                log.warn("Redis: Failed to get queue length.", new Exception(ex));
-                event.reply(new JsonObject().put(STATUS, ERROR));
-            });
-
-        } else {
+        if (true) throw new NoStacktraceException(/*TODO*/"not impl yet aoqör5hgjuaöoiwetrjaöelk");
+        if (!handleQueues.succeeded()) {
             log.warn("Concealed error", new Exception(handleQueues.cause()));
             event.reply(new JsonObject().put(STATUS, ERROR));
+            return;
         }
+        var ctx = new Object() {
+            Redis redis;
+            Iterator<String> iter;
+            /* TODO this filterByPattern is EVIL! Kill it! */
+            List<String> queues = HandlerUtil.filterByPattern(handleQueues.result(), filterPattern);
+            int iNumberResult;
+            int[] queueLengths; /*TODO consider using primitive type*/
+        };
+        if (ctx.queues.isEmpty()) {
+            log.debug("Queue count evaluation with empty queues");
+            event.reply(new JsonObject().put(STATUS, OK).put(QUEUES, new JsonArray()));
+            return;
+        }
+        redisProvider.connection().compose((Redis redis_) -> {
+            assert redis_ != null : "redis_ != null";
+            assert ctx.redis == null : "ctx.redis == null";
+            assert ctx.iter == null : "ctx.iter == null";
+            assert ctx.queueLengths == null : "ctx.queueLengths == null";
+            ctx.redis = redis_;
+            ctx.queueLengths = new int[ctx.queues.size()];
+            ctx.iter = ctx.queues.iterator();
+            var p = Promise.<Void>promise();
+            upperBoundParallel.request(redisRequestQuota, null, new UpperBoundParallel.Mentor<Void>() {
+                @Override public boolean runOneMore(BiConsumer<Throwable, Void> onDone, Void unused) {
+                    if (ctx.iter.hasNext()) {
+                        String queue = ctx.iter.next();
+                        int iNum = ctx.iNumberResult++;
+                        ctx.redis.send(Request.cmd(Command.LLEN, queuesPrefix + queue)).onSuccess((Response rsp) -> {
+                            ctx.queueLengths[iNum] = rsp.toInteger();
+                            onDone.accept(null, null);
+                        }).onFailure(ex -> {
+                            onDone.accept(ex, null);
+                        });
+                    }
+                    return ctx.iter.hasNext();
+                }
+                @Override public boolean onError(Throwable ex, Void ctx_) {
+                    log.error("Unexpected queue length result", new Exception(ex));
+                    event.reply(new JsonObject().put(STATUS, ERROR));
+                    return false;
+                }
+                @Override public void onDone(Void ctx_) {
+                    p.complete();
+                }
+            });
+            return p.future();
+        }).compose((Void v) -> {
+            /*going to waste another threads time to produce those garbage objects*/
+            return vertx.<JsonObject>executeBlocking((Promise<JsonObject> workerPromise) -> {
+                assert !Thread.currentThread().getName().toUpperCase().contains("EVENTLOOP");
+                long beginEpchMs = currentTimeMillis();
+                JsonArray result = new JsonArray();
+                for (int i = 0; i < ctx.queueLengths.length; ++i) {
+                    String queueName = ctx.queues.get(i);
+                    result.add(new JsonObject()
+                            .put(MONITOR_QUEUE_NAME, queueName)
+                            .put(MONITOR_QUEUE_SIZE, ctx.queueLengths[i]));
+                }
+                var obj = new JsonObject().put(STATUS, OK).put(QUEUES, result);
+                long jsonCreateDurationMs = currentTimeMillis() - beginEpchMs;
+                log.info("Creating JSON with {} entries took {}ms", ctx.queueLengths.length, jsonCreateDurationMs);
+                workerPromise.complete(obj);
+            }, false);
+        }).onSuccess((JsonObject json) -> {
+            log.trace("call event.reply(json)");
+            event.reply(json);
+        }).onFailure(ex -> {
+            log.warn("Redis: Failed to get queue length.", new Exception(ex));
+            event.reply(new JsonObject().put(STATUS, ERROR));
+        });
     }
 
 }

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -63,7 +63,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
     private static final String EMPTY_QUEUES_PARAM = "emptyQueues";
     private static final String DELETED = "deleted";
 
-    /** @deprecated TODO <a href="https://xkcd.com/1179/">about date formats</a> */
+    /** @deprecated <a href="https://xkcd.com/1179/">about obsolete date formats</a> */
     @Deprecated
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
 

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -603,8 +603,9 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
         for (Throwable cause = ex.getCause(); cause != null; cause = cause.getCause()) {
             if (!(cause instanceof ReplyException)) continue;
             ReplyException replyException = (ReplyException) cause;
-            if (replyException.failureCode() == StatusCode.INSUFFICIENT_STORAGE.getStatusCode()) {
-                return StatusCode.INSUFFICIENT_STORAGE;
+            int errCode = replyException.failureCode();
+            if (errCode == StatusCode.TOO_MANY_REQUESTS.getStatusCode()) {
+                return StatusCode.TOO_MANY_REQUESTS;
             }
         }
         return defaultValue;

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -588,12 +588,11 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
 
         @Override
         public void onError(Throwable ex, RoutingContext ctx) {
-            String exMsg = ex.getMessage();
-            if (!ctx.response().ended()) {
+            if (!ctx.response().headWritten()) {
                 log.debug("Failed to serve queue stats", ex);
-                respondWith(StatusCode.INTERNAL_SERVER_ERROR, exMsg, ctx.request());
+                respondWith(StatusCode.INTERNAL_SERVER_ERROR, ex.getMessage(), ctx.request());
             } else {
-                log.warn("_q938hugz_ {}", ctx.request().uri(), ex);
+                log.warn("Response already written. MUST let it run into timeout now (error_qykCAJ8aAgCSfAIA1kMC): {}", ctx.request().uri(), ex);
             }
         }
 

--- a/src/main/java/org/swisspush/redisques/scheduling/PeriodicSkipScheduler.java
+++ b/src/main/java/org/swisspush/redisques/scheduling/PeriodicSkipScheduler.java
@@ -5,7 +5,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static java.lang.System.currentTimeMillis;

--- a/src/main/java/org/swisspush/redisques/scheduling/PeriodicSkipScheduler.java
+++ b/src/main/java/org/swisspush/redisques/scheduling/PeriodicSkipScheduler.java
@@ -1,0 +1,76 @@
+package org.swisspush.redisques.scheduling;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+
+import java.util.function.Consumer;
+
+import static java.lang.System.currentTimeMillis;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Same idea as {@link Vertx#setPeriodic(long, long, Handler)}. BUT prevents
+ * tasks which start to overtake themself.
+ */
+public class PeriodicSkipScheduler {
+
+    private static final Logger log = getLogger(PeriodicSkipScheduler.class);
+    private final Vertx vertx;
+
+    public PeriodicSkipScheduler(Vertx vertx) {
+        assert vertx != null;
+        this.vertx = vertx;
+    }
+
+    /** Convenience overload for {@link #setPeriodic(long, long, Consumer)}. */
+    public Timer setPeriodic(long periodMs, Consumer<Runnable> task) {
+        return setPeriodic(periodMs, periodMs, task);
+    }
+
+    /**
+     * Same idea as {@link Vertx#setPeriodic(long, long, Handler)}. BUT prevents
+     * tasks which start to overtake themself.
+     */
+    public Timer setPeriodic(long initDelayMy, long periodMs, Consumer<Runnable> task) {
+        var timer = new Timer(task);
+        timer.id = vertx.setPeriodic(initDelayMy, periodMs, timer::onTrigger_);
+        return timer;
+    }
+
+    private void onTrigger(Timer timer) {
+        long now = currentTimeMillis();
+        boolean isPreviousStillRunning = timer.begEpochMs > timer.endEpochMs;
+        if (isPreviousStillRunning) {
+            log.debug("Previous task still running. We have to NOT run in this interval. Previous did not respond for {}ms.",
+                    now - timer.begEpochMs);
+            return;
+        }
+        timer.begEpochMs = currentTimeMillis();
+        timer.task.accept(timer::onTaskDone_);
+    }
+
+    private void onTaskDone(Timer timer) {
+        timer.endEpochMs = currentTimeMillis();
+    }
+
+    private void cancel(Timer timer) {
+        vertx.cancelTimer(timer.id);
+    }
+
+
+    public class Timer {
+        private final Consumer<Runnable> task;
+        private long id;
+        // When the last run has begun and end.
+        private long begEpochMs, endEpochMs;
+
+        private Timer(Consumer<Runnable> task) {
+            this.task = task;
+        }
+        private void onTrigger_(Long aLong) { onTrigger(this); }
+        private void onTaskDone_() { onTaskDone(this); }
+        public void cancel() { PeriodicSkipScheduler.this.cancel(this); }
+    }
+
+}

--- a/src/main/java/org/swisspush/redisques/scheduling/PeriodicSkipScheduler.java
+++ b/src/main/java/org/swisspush/redisques/scheduling/PeriodicSkipScheduler.java
@@ -49,7 +49,6 @@ public class PeriodicSkipScheduler {
             return;
         }
         timer.begEpochMs = currentTimeMillis();
-        timer.task.accept(timer::onTaskDone_);
         Promise<Void> p = Promise.promise();
         var fut = p.future();
         fut.onSuccess((Void v) -> timer.onTaskDone_());

--- a/src/main/java/org/swisspush/redisques/util/QueueActionFactory.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueActionFactory.java
@@ -3,6 +3,7 @@ package org.swisspush.redisques.util;
 import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.swisspush.redisques.action.*;
+import org.swisspush.redisques.exception.ExceptionFactory;
 
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -21,6 +22,7 @@ public class QueueActionFactory {
     private final QueueStatisticsCollector queueStatisticsCollector;
     private final int memoryUsageLimitPercent;
     private final MemoryUsageProvider memoryUsageProvider;
+    private final ExceptionFactory exceptionFactory;
     private final Semaphore getQueuesItemsCountRedisRequestQuota;
 
     private final RedisquesConfigurationProvider configurationProvider;
@@ -29,6 +31,7 @@ public class QueueActionFactory {
                               String queuesKey, String queuesPrefix, String consumersPrefix,
                               String locksKey, QueueStatisticsCollector queueStatisticsCollector, MemoryUsageProvider memoryUsageProvider,
                               RedisquesConfigurationProvider configurationProvider,
+                              ExceptionFactory exceptionFactory,
                               Semaphore getQueuesItemsCountRedisRequestQuota
     ) {
         this.redisProvider = redisProvider;
@@ -45,6 +48,7 @@ public class QueueActionFactory {
         this.address = configurationProvider.configuration().getAddress();
         this.queueConfigurations = configurationProvider.configuration().getQueueConfigurations();
         this.memoryUsageLimitPercent = configurationProvider.configuration().getMemoryUsageLimitPercent();
+        this.exceptionFactory = exceptionFactory;
         this.getQueuesItemsCountRedisRequestQuota = getQueuesItemsCountRedisRequestQuota;
     }
 
@@ -82,7 +86,7 @@ public class QueueActionFactory {
                         consumersPrefix, locksKey, queueConfigurations, queueStatisticsCollector, log);
             case getQueuesItemsCount:
                 return new GetQueuesItemsCountAction(vertx, redisProvider, address, queuesKey, queuesPrefix,
-                        consumersPrefix, locksKey, queueConfigurations, getQueuesItemsCountRedisRequestQuota, queueStatisticsCollector, log);
+                        consumersPrefix, locksKey, queueConfigurations, exceptionFactory, getQueuesItemsCountRedisRequestQuota, queueStatisticsCollector, log);
             case enqueue:
                 return new EnqueueAction(vertx, redisProvider, address, queuesKey, queuesPrefix,
                         consumersPrefix, locksKey, queueConfigurations, queueStatisticsCollector, log, memoryUsageProvider,

--- a/src/main/java/org/swisspush/redisques/util/QueueActionFactory.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueActionFactory.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.swisspush.redisques.action.*;
 
 import java.util.List;
+import java.util.concurrent.Semaphore;
 
 public class QueueActionFactory {
 
@@ -20,13 +21,16 @@ public class QueueActionFactory {
     private final QueueStatisticsCollector queueStatisticsCollector;
     private final int memoryUsageLimitPercent;
     private final MemoryUsageProvider memoryUsageProvider;
+    private final Semaphore getQueuesItemsCountRedisRequestQuota;
 
     private final RedisquesConfigurationProvider configurationProvider;
 
     public QueueActionFactory(RedisProvider redisProvider, Vertx vertx, Logger log,
                               String queuesKey, String queuesPrefix, String consumersPrefix,
                               String locksKey, QueueStatisticsCollector queueStatisticsCollector, MemoryUsageProvider memoryUsageProvider,
-                              RedisquesConfigurationProvider configurationProvider) {
+                              RedisquesConfigurationProvider configurationProvider,
+                              Semaphore getQueuesItemsCountRedisRequestQuota
+    ) {
         this.redisProvider = redisProvider;
         this.vertx = vertx;
         this.log = log;
@@ -41,6 +45,7 @@ public class QueueActionFactory {
         this.address = configurationProvider.configuration().getAddress();
         this.queueConfigurations = configurationProvider.configuration().getQueueConfigurations();
         this.memoryUsageLimitPercent = configurationProvider.configuration().getMemoryUsageLimitPercent();
+        this.getQueuesItemsCountRedisRequestQuota = getQueuesItemsCountRedisRequestQuota;
     }
 
     public QueueAction buildQueueAction(RedisquesAPI.QueueOperation queueOperation){
@@ -77,7 +82,7 @@ public class QueueActionFactory {
                         consumersPrefix, locksKey, queueConfigurations, queueStatisticsCollector, log);
             case getQueuesItemsCount:
                 return new GetQueuesItemsCountAction(vertx, redisProvider, address, queuesKey, queuesPrefix,
-                        consumersPrefix, locksKey, queueConfigurations, queueStatisticsCollector, log);
+                        consumersPrefix, locksKey, queueConfigurations, getQueuesItemsCountRedisRequestQuota, queueStatisticsCollector, log);
             case enqueue:
                 return new EnqueueAction(vertx, redisProvider, address, queuesKey, queuesPrefix,
                         consumersPrefix, locksKey, queueConfigurations, queueStatisticsCollector, log, memoryUsageProvider,

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -15,6 +15,7 @@ import io.vertx.redis.client.Response;
 import io.vertx.redis.client.impl.types.NumberType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.swisspush.redisques.exception.NoStacktraceException;
 import org.swisspush.redisques.performance.UpperBoundParallel;
 
 import java.util.HashMap;
@@ -361,18 +362,18 @@ public class QueueStatisticsCollector {
                 redisProvider.redis()
                         .onSuccess(redisAPI -> {
                             redisAPI.hset(List.of(STATSKEY, queueName, obj.toString()), ev -> {
-                                onDone.accept(ev.failed() ? new RuntimeException("stack", ev.cause()) : null, null);
+                                onDone.accept(ev.failed() ? new NoStacktraceException("TODO_Wn0CANwoAgAZDwIA20gC error handling", ev.cause()) : null, null);
                             });
                         })
-                        .onFailure(ex -> onDone.accept(new RuntimeException("stack", ex), null));
+                        .onFailure(ex -> onDone.accept(new NoStacktraceException("TODO_H30CACQ6AgAUWwIAoCYC error handling", ex), null));
             } else {
                 redisProvider.redis()
                         .onSuccess(redisAPI -> {
                             redisAPI.hdel(List.of(STATSKEY, queueName), ev -> {
-                                onDone.accept(ev.failed() ? new RuntimeException("stack", ev.cause()) : null, null);
+                                onDone.accept(ev.failed() ? new NoStacktraceException("TODO_Vn4CACQIAgDeLAIAUyEC error handling", ev.cause()) : null, null);
                             });
                         })
-                        .onFailure(ex -> onDone.accept(new RuntimeException("stack", ex), null));
+                        .onFailure(ex -> onDone.accept(new NoStacktraceException("TODO_Kn4CABJoAgBvaQIA7QQC error handling", ex), null));
             }
         } catch (RuntimeException ex) {
             onDone.accept(ex, null);

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -72,20 +72,20 @@ public class QueueStatisticsCollector {
     private final RedisProvider redisProvider;
     private final String queuePrefix;
     private final Vertx vertx;
-    private final Semaphore redisRequestLimit;
+    private final Semaphore redisRequestQuota;
     private final UpperBoundParallel upperBoundParallel;
 
     public QueueStatisticsCollector(
         RedisProvider redisProvider,
         String queuePrefix,
         Vertx vertx,
-        Semaphore redisRequestLimit,
+        Semaphore redisRequestQuota,
         int speedIntervalSec
     ) {
         this.redisProvider = redisProvider;
         this.queuePrefix = queuePrefix;
         this.vertx = vertx;
-        this.redisRequestLimit = redisRequestLimit;
+        this.redisRequestQuota = redisRequestQuota;
         this.upperBoundParallel = new UpperBoundParallel(vertx);
         speedStatisticsScheduler(speedIntervalSec);
     }
@@ -175,7 +175,7 @@ public class QueueStatisticsCollector {
             onDone.accept(null, null);
             return;
         }
-        upperBoundParallel.request(redisRequestLimit, null, new UpperBoundParallel.Mentor<Void>() {
+        upperBoundParallel.request(redisRequestQuota, null, new UpperBoundParallel.Mentor<Void>() {
             int i = 0;
             final int size = queues.size();
             @Override public boolean runOneMore(BiConsumer<Throwable, Void> onDone, Void ctx) {

--- a/src/main/java/org/swisspush/redisques/util/StatusCode.java
+++ b/src/main/java/org/swisspush/redisques/util/StatusCode.java
@@ -14,6 +14,7 @@ public enum StatusCode {
     NOT_FOUND(404, "Not Found"),
     METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
     CONFLICT(409, "Conflict"),
+    TOO_MANY_REQUESTS(429, "Too Many Requests"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
     SERVICE_UNAVAILABLE(503, "Service Unavailable"),
     TIMEOUT(504,"Gateway Timeout"),


### PR DESCRIPTION
Relates to SDCISA-15833, Probably fixes https://github.com/swisspost/vertx-redisques/pull/170 .

Usage example (*replace dots with your respective quota*):
```java
  RedisQues.builder()
      .withRedisMonitoringReqQuota(...)
      .withCheckQueueRequestsQuota(...)
      .withQueueStatsRequestQuota(...)
      .withGetQueuesItemsCountRedisRequestQuota(...)
      .build();
```
If nothing is configured, RedisQues will use INT_MAX to emulate the behavior as it was before.
