### PR TITLE
Always use the RedisAPI

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -14,9 +14,7 @@ import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Command;
-import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
-import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -677,10 +675,9 @@ public class RedisQues extends AbstractVerticle {
 
     private void registerQueueCheck() {
         vertx.setPeriodic(configurationProvider.configuration().getCheckIntervalTimerMs(), periodicEvent -> {
-            redisProvider.connection().<Response>compose((Redis conn) -> {
+            redisProvider.redis().<Response>compose((RedisAPI redisAPI) -> {
                 int checkInterval = configurationProvider.configuration().getCheckInterval();
-                Request req = Request.cmd(Command.SET, queueCheckLastexecKey, currentTimeMillis(), "NX", "EX", checkInterval);
-                return conn.send(req);
+                return redisAPI.send(Command.SET, queueCheckLastexecKey, String.valueOf(currentTimeMillis()), "NX", "EX", String.valueOf(checkInterval));
             }).<Void>compose((Response todoExplainWhyThisIsIgnored) -> {
                 log.info("periodic queue check is triggered now");
                 return checkQueues();

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -997,7 +997,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                         }
                     } else {
                         String error = "Error gathering names of active queues";
-                        log.error(error);
+                        log.error(error, reply.cause());
                         respondWith(StatusCode.INTERNAL_SERVER_ERROR, error, ctx.request());
                     }
                 });

--- a/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandler.java
@@ -997,7 +997,7 @@ public class RedisquesHttpRequestHandler implements Handler<HttpServerRequest> {
                         }
                     } else {
                         String error = "Error gathering names of active queues";
-                        log.error(error, reply.cause());
+                        log.error(error, exceptionFactory.newException(reply.cause()));
                         respondWith(StatusCode.INTERNAL_SERVER_ERROR, error, ctx.request());
                     }
                 });

--- a/src/main/java/org/swisspush/redisques/util/DefaultRedisProvider.java
+++ b/src/main/java/org/swisspush/redisques/util/DefaultRedisProvider.java
@@ -47,15 +47,6 @@ public class DefaultRedisProvider implements RedisProvider {
         }
     }
 
-    @Override
-    public Future<Redis> connection() {
-        if (redis != null) {
-            return Future.succeededFuture(redis);
-        } else {
-            return setupRedisClient().compose(redisAPI -> Future.succeededFuture(redis));
-        }
-    }
-
     private boolean reconnectEnabled() {
         return configurationProvider.configuration().getRedisReconnectAttempts() != 0;
     }

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -7,15 +7,12 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Command;
-import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
-import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.impl.types.NumberType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
-import org.swisspush.redisques.exception.NoStacktraceException;
 import org.swisspush.redisques.performance.UpperBoundParallel;
 
 import java.util.ArrayList;
@@ -485,13 +482,12 @@ public class QueueStatisticsCollector {
      */
     Future<Void> step1(RequestCtx ctx) {
         final Promise<Void> promise = Promise.promise();
-        redisProvider.connection()
+        redisProvider.redis()
                 .onFailure(throwable -> {
                     promise.fail(new Exception("Redis: Failed to get queue length.", throwable));
                 })
                 .onSuccess(conn -> {
                     assert conn != null;
-                    ctx.conn = conn;
                     promise.complete();
                 });
         return promise.future();
@@ -509,7 +505,7 @@ public class QueueStatisticsCollector {
         Future<NumberType> execute() {
             // switch to a worker thread
             return vertx.executeBlocking(promise -> {
-                ctx.conn.send(Request.cmd(Command.LLEN, queuePrefix + queueName)).onComplete(event -> {
+                ctx.redisAPI.send(Command.LLEN, queuePrefix + queueName).onComplete(event -> {
                     if (event.failed()) {
                         promise.fail(event.cause());
                         return;
@@ -522,7 +518,7 @@ public class QueueStatisticsCollector {
 
     /** <p>Query queue lengths.</p> */
     Future<Void> step2(RequestCtx ctx) {
-        assert ctx.conn != null;
+        assert ctx.redisAPI != null;
         int numQueues = ctx.queueNames.size();
 
         return vertx.executeBlocking(executeBlockingPromise -> {
@@ -687,7 +683,6 @@ public class QueueStatisticsCollector {
      *  request.</p> */
     private static class RequestCtx {
         private List<String> queueNames; // Requested queues to analyze
-        private Redis conn;
         private RedisAPI redisAPI;
         private List<NumberType> queueLengthList;
         private HashMap<String, QueueStatistic> statistics; // Stats we're going to populate

--- a/src/main/java/org/swisspush/redisques/util/RedisProvider.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisProvider.java
@@ -1,7 +1,6 @@
 package org.swisspush.redisques.util;
 
 import io.vertx.core.Future;
-import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 
 /**
@@ -10,8 +9,5 @@ import io.vertx.redis.client.RedisAPI;
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
 public interface RedisProvider {
-
     Future<RedisAPI> redis();
-
-    Future<Redis> connection();
 }


### PR DESCRIPTION
With this PR we remove below method and always use the RedisAPI

RedisProvider

Future<Redis> connection();