### PR TITLE
Pass error information through to caller in place of out-of-context logging

### DIFF
--- a/src/main/java/org/swisspush/redisques/QueueStatsService.java
+++ b/src/main/java/org/swisspush/redisques/QueueStatsService.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static java.lang.Long.compare;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
@@ -72,7 +71,7 @@ public class QueueStatsService {
 
     public <CTX> void getQueueStats(CTX mCtx, GetQueueStatsMentor<CTX> mentor) {
         if (!incomingRequestQuota.tryAcquire()) {
-            Throwable ex = exceptionFactory.newReplyException(RECIPIENT_FAILURE, 429,
+            Throwable ex = exceptionFactory.newReplyException(429,
                     "Server too busy to handle yet-another-queue-stats-request now", null);
             vertx.runOnContext(v -> mentor.onError(ex, mCtx));
             return;

--- a/src/main/java/org/swisspush/redisques/action/AbstractQueueAction.java
+++ b/src/main/java/org/swisspush/redisques/action/AbstractQueueAction.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 public abstract class AbstractQueueAction implements QueueAction {
@@ -60,9 +61,8 @@ public abstract class AbstractQueueAction implements QueueAction {
         };
     }
 
-    protected void handleFail(Message<JsonObject> event, String message, Throwable throwable) {
-        log.warn(message, exceptionFactory.newException(throwable));
-        event.fail(0, throwable.getMessage());
+    protected void handleFail(Message<JsonObject> event, String message, Throwable cause) {
+        event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, cause));
     }
 
     protected long getMaxAgeTimestamp() {

--- a/src/main/java/org/swisspush/redisques/action/AbstractQueueAction.java
+++ b/src/main/java/org/swisspush/redisques/action/AbstractQueueAction.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 public abstract class AbstractQueueAction implements QueueAction {
@@ -61,8 +60,8 @@ public abstract class AbstractQueueAction implements QueueAction {
         };
     }
 
-    protected void handleFail(Message<JsonObject> event, String message, Throwable cause) {
-        event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, cause));
+    protected void handleFail(Message<JsonObject> event, String msg, Throwable cause) {
+        event.reply(exceptionFactory.newReplyException(msg, cause));
     }
 
     protected long getMaxAgeTimestamp() {

--- a/src/main/java/org/swisspush/redisques/action/GetQueueItemsAction.java
+++ b/src/main/java/org/swisspush/redisques/action/GetQueueItemsAction.java
@@ -12,7 +12,6 @@ import org.swisspush.redisques.util.RedisProvider;
 
 import java.util.List;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 public class GetQueueItemsAction extends AbstractQueueAction {
@@ -38,8 +37,8 @@ public class GetQueueItemsAction extends AbstractQueueAction {
                 redisAPI.lrange(keyListRange, "0", String.valueOf(maxQueueItemCountIndex),
                         new GetQueueItemsHandler(event, queueItemCount));
             } else {
-                event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0,
-                        "Operation getQueueItems failed to extract queueItemCount", null));
+                event.reply(exceptionFactory.newReplyException(
+                    "Operation getQueueItems failed to extract queueItemCount", null));
             }
         }).onFailure(throwable -> handleFail(event, "Operation getQueueItems failed", throwable)))
                 .onFailure(throwable -> handleFail(event, "Operation getQueueItems failed", throwable));

--- a/src/main/java/org/swisspush/redisques/action/GetQueueItemsAction.java
+++ b/src/main/java/org/swisspush/redisques/action/GetQueueItemsAction.java
@@ -12,6 +12,7 @@ import org.swisspush.redisques.util.RedisProvider;
 
 import java.util.List;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.swisspush.redisques.util.RedisquesAPI.*;
 
 public class GetQueueItemsAction extends AbstractQueueAction {
@@ -37,9 +38,8 @@ public class GetQueueItemsAction extends AbstractQueueAction {
                 redisAPI.lrange(keyListRange, "0", String.valueOf(maxQueueItemCountIndex),
                         new GetQueueItemsHandler(event, queueItemCount));
             } else {
-                String msg = "Operation getQueueItems failed to extract queueItemCount";
-                log.warn(msg);
-                event.fail(0, msg);
+                event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0,
+                        "Operation getQueueItems failed to extract queueItemCount", null));
             }
         }).onFailure(throwable -> handleFail(event, "Operation getQueueItems failed", throwable)))
                 .onFailure(throwable -> handleFail(event, "Operation getQueueItems failed", throwable));

--- a/src/main/java/org/swisspush/redisques/exception/RedisQuesExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/RedisQuesExceptionFactory.java
@@ -1,7 +1,6 @@
 package org.swisspush.redisques.exception;
 
 import io.vertx.core.eventbus.ReplyException;
-import io.vertx.core.eventbus.ReplyFailure;
 
 
 /**
@@ -30,7 +29,11 @@ public interface RedisQuesExceptionFactory {
 
     public RuntimeException newRuntimeException(String message, Throwable cause);
 
-    public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String msg, Throwable cause);
+    default ReplyException newReplyException(String msg, Throwable cause) {
+        return newReplyException(0, msg, cause);
+    }
+
+    public ReplyException newReplyException(int failureCode, String msg, Throwable cause);
 
 
     /**

--- a/src/main/java/org/swisspush/redisques/exception/ThriftyRedisQuesExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/ThriftyRedisQuesExceptionFactory.java
@@ -33,13 +33,13 @@ class ThriftyRedisQuesExceptionFactory implements RedisQuesExceptionFactory {
     }
 
     @Override
-    public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String msg, Throwable cause) {
+    public ReplyException newReplyException(int failureCode, String msg, Throwable cause) {
         // There was once a fix in vertx for this (https://github.com/eclipse-vertx/vert.x/issues/4840)
         // but for whatever reason in our case we still see stack-trace recordings. Passing
         // this subclass to {@link io.vertx.core.eventbus.Message#reply(Object)} seems to
         // do the trick.
         if (msg == null && cause != null) msg = cause.getMessage();
-        return new ReplyException(failureType, failureCode, msg) {
+        return new ReplyException(ReplyFailure.RECIPIENT_FAILURE, failureCode, msg) {
             @Override public Throwable fillInStackTrace() { return this; }
         };
     }

--- a/src/main/java/org/swisspush/redisques/exception/WastefulRedisQuesExceptionFactory.java
+++ b/src/main/java/org/swisspush/redisques/exception/WastefulRedisQuesExceptionFactory.java
@@ -26,9 +26,9 @@ class WastefulRedisQuesExceptionFactory implements RedisQuesExceptionFactory {
     }
 
     @Override
-    public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String msg, Throwable cause) {
+    public ReplyException newReplyException(int failureCode, String msg, Throwable cause) {
         if (msg == null && cause != null) msg = cause.getMessage();
-        ReplyException ex = new ReplyException(failureType, failureCode, msg);
+        ReplyException ex = new ReplyException(ReplyFailure.RECIPIENT_FAILURE, failureCode, msg);
         if (cause != null) ex.initCause(cause);
         return ex;
     }

--- a/src/main/java/org/swisspush/redisques/handler/AddQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/AddQueueItemHandler.java
@@ -8,7 +8,6 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -34,7 +33,7 @@ public class AddQueueItemHandler implements Handler<AsyncResult<Response>> {
         if(reply.succeeded()){
             event.reply(new JsonObject().put(STATUS, OK));
         } else {
-            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, reply.cause()));
+            event.reply(exceptionFactory.newReplyException(null, reply.cause()));
         }
     }
 }

--- a/src/main/java/org/swisspush/redisques/handler/AddQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/AddQueueItemHandler.java
@@ -8,6 +8,7 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -33,8 +34,7 @@ public class AddQueueItemHandler implements Handler<AsyncResult<Response>> {
         if(reply.succeeded()){
             event.reply(new JsonObject().put(STATUS, OK));
         } else {
-            log.warn("Concealed error", exceptionFactory.newException(reply.cause()));
-            event.fail(0, reply.cause().getMessage());
+            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, reply.cause()));
         }
     }
 }

--- a/src/main/java/org/swisspush/redisques/handler/DeleteLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/DeleteLockHandler.java
@@ -8,7 +8,6 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -34,7 +33,7 @@ public class DeleteLockHandler implements Handler<AsyncResult<Response>> {
         if (reply.succeeded()) {
             event.reply(new JsonObject().put(STATUS, OK));
         } else {
-            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, reply.cause()));
+            event.reply(exceptionFactory.newReplyException(null, reply.cause()));
         }
     }
 }

--- a/src/main/java/org/swisspush/redisques/handler/DeleteLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/DeleteLockHandler.java
@@ -8,6 +8,7 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -33,8 +34,7 @@ public class DeleteLockHandler implements Handler<AsyncResult<Response>> {
         if (reply.succeeded()) {
             event.reply(new JsonObject().put(STATUS, OK));
         } else {
-            log.warn("Concealed error", exceptionFactory.newException(reply.cause()));
-            event.fail(0, reply.cause().getMessage());
+            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, reply.cause()));
         }
     }
 }

--- a/src/main/java/org/swisspush/redisques/handler/GetLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetLockHandler.java
@@ -8,7 +8,6 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.NO_SUCH_LOCK;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
@@ -40,7 +39,7 @@ public class GetLockHandler implements Handler<AsyncResult<Response>> {
                 event.reply(new JsonObject().put(STATUS, NO_SUCH_LOCK));
             }
         } else {
-            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, reply.cause()));
+            event.reply(exceptionFactory.newReplyException(null, reply.cause()));
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/GetLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetLockHandler.java
@@ -8,6 +8,7 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.NO_SUCH_LOCK;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
@@ -39,8 +40,7 @@ public class GetLockHandler implements Handler<AsyncResult<Response>> {
                 event.reply(new JsonObject().put(STATUS, NO_SUCH_LOCK));
             }
         } else {
-            log.warn("Concealed error", exceptionFactory.newException(reply.cause()));
-            event.fail(0, reply.cause().getMessage());
+            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, null, reply.cause()));
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/GetQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueueItemHandler.java
@@ -33,8 +33,7 @@ public class GetQueueItemHandler implements Handler<AsyncResult<Response>> {
     @Override
     public void handle(AsyncResult<Response> reply) {
         if(reply.failed()) {
-            log.warn("Concealed error", exceptionFactory.newException(reply.cause()));
-            event.fail(0, reply.cause().getMessage());
+            event.reply(exceptionFactory.newReplyException(io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE, 0, null, reply.cause()));
         } else if (reply.result() != null) {
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, reply.result().toString()));
         } else {

--- a/src/main/java/org/swisspush/redisques/handler/GetQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueueItemHandler.java
@@ -33,7 +33,7 @@ public class GetQueueItemHandler implements Handler<AsyncResult<Response>> {
     @Override
     public void handle(AsyncResult<Response> reply) {
         if(reply.failed()) {
-            event.reply(exceptionFactory.newReplyException(io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE, 0, null, reply.cause()));
+            event.reply(exceptionFactory.newReplyException(null, reply.cause()));
         } else if (reply.result() != null) {
             event.reply(new JsonObject().put(STATUS, OK).put(VALUE, reply.result().toString()));
         } else {

--- a/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/GetQueuesItemsCountHandler.java
@@ -5,7 +5,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.redis.client.Command;
@@ -87,7 +86,7 @@ public class GetQueuesItemsCountHandler implements Handler<AsyncResult<Response>
             return;
         }
         if (redisRequestQuota.availablePermits() <= 0) {
-            event.reply(exceptionFactory.newReplyException(ReplyFailure.RECIPIENT_FAILURE, 429,
+            event.reply(exceptionFactory.newReplyException(429,
                     "Too many simultaneous '" + GetQueuesItemsCountHandler.class.getSimpleName() + "' requests in progress", null));
             return;
         }

--- a/src/main/java/org/swisspush/redisques/handler/PutLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/PutLockHandler.java
@@ -8,7 +8,6 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -34,7 +33,7 @@ public class PutLockHandler implements Handler<AsyncResult<Response>> {
         if(reply.succeeded()){
             event.reply(new JsonObject().put(STATUS, OK));
         } else {
-            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, reply.cause().getMessage(), reply.cause()));
+            event.reply(exceptionFactory.newReplyException(reply.cause().getMessage(), reply.cause()));
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/PutLockHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/PutLockHandler.java
@@ -8,6 +8,7 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -33,8 +34,7 @@ public class PutLockHandler implements Handler<AsyncResult<Response>> {
         if(reply.succeeded()){
             event.reply(new JsonObject().put(STATUS, OK));
         } else {
-            log.warn("Concealed error", exceptionFactory.newException(reply.cause()));
-            event.fail(0, reply.cause().getMessage());
+            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, reply.cause().getMessage(), reply.cause()));
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/ReplaceQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/ReplaceQueueItemHandler.java
@@ -8,6 +8,7 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
@@ -36,8 +37,7 @@ public class ReplaceQueueItemHandler implements Handler<AsyncResult<Response>> {
         } else if(checkRedisErrorCodes(reply.cause().getMessage())) {
             event.reply(new JsonObject().put(STATUS, ERROR));
         } else {
-            log.warn("Concealed error", exceptionFactory.newException(reply.cause()));
-            event.fail(0, reply.cause().getMessage());
+            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, reply.cause().getMessage(), reply.cause()));
         }
     }
 

--- a/src/main/java/org/swisspush/redisques/handler/ReplaceQueueItemHandler.java
+++ b/src/main/java/org/swisspush/redisques/handler/ReplaceQueueItemHandler.java
@@ -8,7 +8,6 @@ import io.vertx.redis.client.Response;
 import org.slf4j.Logger;
 import org.swisspush.redisques.exception.RedisQuesExceptionFactory;
 
-import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
@@ -37,7 +36,7 @@ public class ReplaceQueueItemHandler implements Handler<AsyncResult<Response>> {
         } else if(checkRedisErrorCodes(reply.cause().getMessage())) {
             event.reply(new JsonObject().put(STATUS, ERROR));
         } else {
-            event.reply(exceptionFactory.newReplyException(RECIPIENT_FAILURE, 0, reply.cause().getMessage(), reply.cause()));
+            event.reply(exceptionFactory.newReplyException(null, reply.cause()));
         }
     }
 

--- a/src/test/java/org/swisspush/redisques/action/AbstractQueueActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/AbstractQueueActionTest.java
@@ -19,6 +19,7 @@ import org.swisspush.redisques.util.RedisProvider;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
+import static org.swisspush.redisques.exception.RedisQuesExceptionFactory.newWastefulExceptionFactory;
 
 public abstract class AbstractQueueActionTest {
 
@@ -40,7 +41,7 @@ public abstract class AbstractQueueActionTest {
     public void setup() {
         redisAPI = Mockito.mock(RedisAPI.class);
         redisProvider = Mockito.mock(RedisProvider.class);
-        exceptionFactory = Mockito.mock(RedisQuesExceptionFactory.class);
+        exceptionFactory = newWastefulExceptionFactory();
         when(redisProvider.redis()).thenReturn(Future.succeededFuture(redisAPI));
 
         memoryUsageProvider = Mockito.mock(MemoryUsageProvider.class);

--- a/src/test/java/org/swisspush/redisques/action/AddQueueItemActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/AddQueueItemActionTest.java
@@ -1,6 +1,7 @@
 package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Before;
@@ -12,6 +13,7 @@ import org.swisspush.redisques.util.QueueStatisticsCollector;
 
 import java.util.ArrayList;
 
+import static io.vertx.core.eventbus.ReplyFailure.RECIPIENT_FAILURE;
 import static org.mockito.Mockito.*;
 import static org.swisspush.redisques.util.RedisquesAPI.buildAddQueueItemOperation;
 
@@ -39,7 +41,7 @@ public class AddQueueItemActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -73,6 +75,6 @@ public class AddQueueItemActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).rpush(anyList(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/BulkDeleteQueuesActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/BulkDeleteQueuesActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
@@ -45,7 +46,7 @@ public class BulkDeleteQueuesActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -78,7 +79,7 @@ public class BulkDeleteQueuesActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).del(anyList(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 
     @Test

--- a/src/test/java/org/swisspush/redisques/action/DeleteAllQueueItemsActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/DeleteAllQueueItemsActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -82,7 +83,7 @@ public class DeleteAllQueueItemsActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -99,7 +100,7 @@ public class DeleteAllQueueItemsActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).del(anyList(), any());
-        verify(message, times(1)).fail(eq(0), eq("boooom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 
     @Test
@@ -122,6 +123,7 @@ public class DeleteAllQueueItemsActionTest extends AbstractQueueActionTest {
 
         verify(redisAPI, times(1)).del(anyList(), any());
         verify(redisAPI, times(1)).hdel(anyList(), any());
-        verify(message, times(1)).fail(eq(0), eq("boooom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
+        //verify(message, times(1)).fail(eq(0), eq("boooom"));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/DeleteLockActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/DeleteLockActionTest.java
@@ -1,6 +1,7 @@
 package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.impl.types.SimpleStringType;
@@ -40,7 +41,7 @@ public class DeleteLockActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -110,6 +111,6 @@ public class DeleteLockActionTest extends AbstractQueueActionTest {
 
         verify(redisAPI, times(1)).exists(anyList(), any());
         verify(redisAPI, times(1)).hdel(anyList(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/DeleteQueueItemActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/DeleteQueueItemActionTest.java
@@ -1,6 +1,7 @@
 package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Before;
@@ -39,7 +40,7 @@ public class DeleteQueueItemActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -57,7 +58,7 @@ public class DeleteQueueItemActionTest extends AbstractQueueActionTest {
 
         verify(redisAPI, times(1)).lset(anyString(), eq("0"), eq("TO_DELETE"), any());
         verify(redisAPI, never()).lrem(anyString(), anyString(), anyString());
-        verify(message, times(1)).fail(eq(0), eq("boooom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 
     @Test
@@ -97,7 +98,7 @@ public class DeleteQueueItemActionTest extends AbstractQueueActionTest {
 
         verify(redisAPI, times(1)).lset(anyString(), eq("0"), eq("TO_DELETE"), any());
         verify(redisAPI, times(1)).lrem(anyString(), eq("0"), eq("TO_DELETE"), any());
-        verify(message, times(1)).fail(eq(0), eq("boooom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 
     @Test

--- a/src/test/java/org/swisspush/redisques/action/GetAllLocksActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/GetAllLocksActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.impl.future.FailedFuture;
 import io.vertx.core.impl.future.SucceededFuture;
 import io.vertx.core.json.JsonObject;
@@ -45,7 +46,7 @@ public class GetAllLocksActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 

--- a/src/test/java/org/swisspush/redisques/action/GetLockActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/GetLockActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -42,7 +43,7 @@ public class GetLockActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -92,6 +93,7 @@ public class GetLockActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).hget(anyString(), anyString(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        //verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/GetQueueItemActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/GetQueueItemActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -42,7 +43,7 @@ public class GetQueueItemActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -92,6 +93,6 @@ public class GetQueueItemActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).lindex(anyString(), anyString(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/GetQueueItemsActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/GetQueueItemsActionTest.java
@@ -1,6 +1,7 @@
 package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.impl.types.SimpleStringType;
@@ -40,7 +41,7 @@ public class GetQueueItemsActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -52,7 +53,7 @@ public class GetQueueItemsActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).llen(anyString());
-        verify(message, times(1)).fail(eq(0), eq("boooom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 
     @Test
@@ -63,6 +64,6 @@ public class GetQueueItemsActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).llen(anyString());
-        verify(message, times(1)).fail(eq(0), eq("Operation getQueueItems failed to extract queueItemCount"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/PutLockActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/PutLockActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -42,7 +43,7 @@ public class PutLockActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -95,6 +96,6 @@ public class PutLockActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).hmset(anyList(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }

--- a/src/test/java/org/swisspush/redisques/action/ReplaceQueueItemActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/ReplaceQueueItemActionTest.java
@@ -2,6 +2,7 @@ package org.swisspush.redisques.action;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -41,7 +42,7 @@ public class ReplaceQueueItemActionTest extends AbstractQueueActionTest {
 
         action.execute(message);
 
-        verify(message, times(1)).fail(eq(0), eq("not ready"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
         verifyNoInteractions(redisAPI);
     }
 
@@ -74,6 +75,6 @@ public class ReplaceQueueItemActionTest extends AbstractQueueActionTest {
         action.execute(message);
 
         verify(redisAPI, times(1)).lset(anyString(), anyString(), anyString(), any());
-        verify(message, times(1)).fail(eq(0), eq("booom"));
+        verify(message, times(1)).reply(isA(ReplyException.class));
     }
 }


### PR DESCRIPTION
Related:
- [Example how stripped error messages make finding bugs unecessary hard](https://github.com/swisspost/gateleen/issues/589)
- [ReplyException](https://github.com/eclipse-vertx/vert.x/blob/4.5.1/src/main/java/io/vertx/core/eventbus/ReplyException.java#L16-L24)
- [ReplyFailure](https://github.com/eclipse-vertx/vert.x/blob/4.5.1/src/main/java/io/vertx/core/eventbus/ReplyFailure.java#L34-L37)
- [reply(Throwable) allows more detailed error messages than fail(int, String) does](https://github.com/eclipse-vertx/vert.x/blob/4.5.1/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java#L101-L105)
