### PR TITLE
Fix misleading log

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -1248,7 +1248,6 @@ public class RedisQues extends AbstractVerticle {
                             }
                         });
                     } else {
-                        log.debug("all queue items time used is {} ms", System.currentTimeMillis() - startTs);
                         onDone.accept(null, null);
                     }
                     return ctx.iter.hasNext();
@@ -1263,6 +1262,7 @@ public class RedisQues extends AbstractVerticle {
                     ctx.counter = null;
                     ctx.iter = null;
                     // Mark this composition step as completed.
+                    log.debug("all queue items time used is {} ms", System.currentTimeMillis() - startTs);
                     p.complete();
                 }
             });


### PR DESCRIPTION
The place where the log was, is NOT where the process has completed, but TOO EARLY. Because other scheduled task runs may are STILL IN PROGRESS when this line is reached. Therefore would log a way too short (aka misleading) duration.

The only place where the method call is really done, is as where the returned future is resolved.