### PR TITLE
SDCISA-18049: Fix dead queues

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -578,6 +578,7 @@ public class RedisQues extends AbstractVerticle {
                     }
                     @Override public boolean onError(Throwable ex, Iterator<Map.Entry<String, QueueState>> iter) {
                         if (log.isWarnEnabled()) log.warn("TODO error handling", exceptionFactory.newException(ex));
+                        onPeriodicDone.run();
                         return false;
                     }
                     @Override public void onDone(Iterator<Map.Entry<String, QueueState>> iter) {


### PR DESCRIPTION
Cited from UpperBoundParallel.Mentor:
```java
        /**
         * Called once as soon the iteration has ended SUCCESSFULLY. It is NOT
         * called if {@link #onError(Throwable, Object)} did request to STOP the
         * iteration for example.
         */
        void onDone(Ctx ctx);
```

Related:
- SDCISA-18274