### PR TITLE
Cleanup consumers that are no longer alive

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -496,12 +496,8 @@ public class RedisQues extends AbstractVerticle {
     private void handleConsumerAlive(Message<String> msg) {
         final String consumerId = msg.body();
         final long periodMs = configurationProvider.configuration().getRefreshPeriod() * 1000L;
-        if (!UUID.fromString(consumerId).toString().equals(consumerId)) {
-            log.warn("invalid RedisQues consumer id {}", consumerId);
-            return;
-        }
-        log.debug("RedisQues consumer {} keep alive renewed", consumerId);
         aliveConsumers.put(consumerId, currentTimeMillis() + (periodMs * 4));
+        log.debug("RedisQues consumer {} keep alive renewed", consumerId);
     }
 
 

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -1208,7 +1208,7 @@ public class RedisQues extends AbstractVerticle {
                         log.warn("RedisQues consumer {} of queue {} does not exist.", consumer, queueName);
                         redisAPI.del(Collections.singletonList(key), result -> {
                             if (result.failed()) {
-                                log.warn("Failed to removed consumer '{}'", key, exceptionFactory.newException(event.cause()));
+                                log.warn("Failed to removed consumer '{}'", key, exceptionFactory.newException(result.cause()));
                             } else {
                                 log.debug("{} consumer key removed",  result.result().toLong());
                             }


### PR DESCRIPTION
With this PR we fix an issue where registrations pointing to no longer existing consumers continue to be refreshed after a server restart