### PR TITLE
SDCISA-18302: Add logging in case unreachable code gets reached.

### DIFF
--- a/src/main/java/org/swisspush/redisques/performance/UpperBoundParallel.java
+++ b/src/main/java/org/swisspush/redisques/performance/UpperBoundParallel.java
@@ -132,7 +132,12 @@ public class UpperBoundParallel {
                         // this boolean is just for paranoia, in case mentor tries to call back too often.
                         final AtomicBoolean isCalled = new AtomicBoolean();
                         @Override public void accept(Throwable ex, Void ret) {
-                            if (!isCalled.compareAndSet(false, true)) return;
+                            if (!isCalled.compareAndSet(false, true)) {
+                                boolean d = log.isDebugEnabled();
+                                log.error("This callback MUST NOT be called multiple times!! Make sure caller only calls it ONCE!{}",
+                                        d ? "" : " (enable debug log to see stack)", d ? new Exception("here a stack for you") : (Exception) null);
+                                return;
+                            }
                             onOneDone(req, ex);
                         }
                     }, req.ctx);


### PR DESCRIPTION
Helps to hunt mis-behaving UpperBoundParallel usages. To find the caller, debug log level can be enabled which prints a stack where the mis-behaving caller (*hopefully*) is listed in.