### PR TITLE
fix unhandled exception

### DIFF
--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -1007,7 +1007,13 @@ public class RedisQues extends AbstractVerticle {
                         String consumer = Objects.toString(event1.result(), "");
                         log.trace("RedisQues refresh registration consumer: {}", consumer);
                         if (uid.equals(consumer)) {
-                            QueueState state = myQueues.get(queueName).state;
+                            QueueProcessingState queueProcessingState = myQueues.get(queueName);
+                            if (queueProcessingState == null) {
+                                log.trace("RedisQues Queue {} is already being consumed or handed by other consumer", queueName);
+                                promise.complete();
+                                return;
+                            }
+                            QueueState state = queueProcessingState.state;
                             log.trace("RedisQues consumer: {} queue: {} state: {}", consumer, queueName, state);
                             // Get the next message only once the previous has
                             // been completely processed


### PR DESCRIPTION
java.lang.NullPointerException: Cannot read field "state" because the return value of "java.util.Map.get(Object)" is null
	at org.swisspush.redisques.RedisQues.lambda$consume$36(RedisQues.java:1007) ~[redisques-4.1.13.jar:?]
	at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176) ~[vertx-core-4.5.1.jar:4.5.1]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[vertx-core-4.5.1.jar:4.5.1]