### PR TITLE
the slow ssl may casue thread blocked exception

### DIFF
--- a/src/main/java/org/swisspush/redisques/queue/QueueRegistryService.java
+++ b/src/main/java/org/swisspush/redisques/queue/QueueRegistryService.java
@@ -228,7 +228,12 @@ public class QueueRegistryService {
         if (handler == null) {
             throw new RuntimeException("Handler must be set");
         } else {
-            redisService.expire(consumerKey, String.valueOf(consumerLockTime)).onComplete(handler);
+            vertx.executeBlocking(promise ->
+                    redisService.expire(consumerKey, String.valueOf(consumerLockTime)).
+                            onComplete(responseAsyncResult -> {
+                                handler.handle(responseAsyncResult);
+                                promise.complete();
+                            }));
         }
     }
 


### PR DESCRIPTION
io.vertx.core.VertxException: Thread blocked
	at java.base/java.security.MessageDigest.isEqual(Unknown Source)
	at java.base/com.sun.crypto.provider.GaloisCounterMode.init(Unknown Source)
	at java.base/com.sun.crypto.provider.GaloisCounterMode.engineInit(Unknown Source)
	at java.base/javax.crypto.Cipher.init(Unknown Source)
	at java.base/sun.security.ssl.SSLCipher$T13GcmWriteCipherGenerator$GcmWriteCipher.encrypt(Unknown Source)
	at java.base/sun.security.ssl.OutputRecord.t13Encrypt(Unknown Source)
	at java.base/sun.security.ssl.OutputRecord.encrypt(Unknown Source)
	at java.base/sun.security.ssl.SSLEngineOutputRecord.encode(Unknown Source)
	at java.base/sun.security.ssl.SSLEngineOutputRecord.encode(Unknown Source)
	at java.base/sun.security.ssl.SSLEngineImpl.encode(Unknown Source)
	at java.base/sun.security.ssl.SSLEngineImpl.writeRecord(Unknown Source)
	at java.base/sun.security.ssl.SSLEngineImpl.wrap(Unknown Source)
	at java.base/sun.security.ssl.SSLEngineImpl.wrap(Unknown Source)
	at java.base/javax.net.ssl.SSLEngine.wrap(Unknown Source)
.
.
	at io.vertx.redis.client.impl.PooledRedisConnection.send(PooledRedisConnection.java:75)
	at io.vertx.redis.client.impl.RedisReplicationConnection.send(RedisReplicationConnection.java:115)
	at io.vertx.redis.client.impl.RedisAPIImpl.send(RedisAPIImpl.java:59)
	at io.vertx.redis.client.RedisAPI.expire(RedisAPI.java:2027)
	at org.swisspush.redisques.queue.RedisService.lambda$expire$32(RedisService.java:237)
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:231)
	at io.vertx.core.impl.future.FutureBase.compose(FutureBase.java:90)
	at io.vertx.core.impl.future.FutureImpl.compose(FutureImpl.java:28)
	at io.vertx.core.Future.compose(Future.java:375)
	at org.swisspush.redisques.queue.RedisService.expire(RedisService.java:236)
	at org.swisspush.redisques.queue.QueueRegistryService.refreshRegistration(QueueRegistryService.java:231)