### PR TITLE
Keep ony top 4 lines in ResourceExhaustionException

### DIFF
--- a/src/main/java/org/swisspush/redisques/exception/ResourceExhaustionException.java
+++ b/src/main/java/org/swisspush/redisques/exception/ResourceExhaustionException.java
@@ -1,5 +1,7 @@
 package org.swisspush.redisques.exception;
 
+import java.util.Arrays;
+
 /**
  * <p>Thrown when something cannot be done right now because some
  * resource is exhausted.</p>
@@ -11,6 +13,7 @@ public class ResourceExhaustionException extends Exception {
 
     public ResourceExhaustionException(String message, Throwable cause) {
         super(message, cause);
+        // only keep 4 lines of stack trace for this exception
+        this.setStackTrace(Arrays.copyOf(this.getStackTrace(), Math.min(4, this.getStackTrace().length)));
     }
-
 }


### PR DESCRIPTION
The exception contains very long stack trace, which are not needed, keep only top 4