### PR TITLE
Fix Off By Factor 1000 (maybe) Bug

### DIFF
--- a/src/main/java/org/swisspush/redisques/util/DefaultRedisProvider.java
+++ b/src/main/java/org/swisspush/redisques/util/DefaultRedisProvider.java
@@ -218,7 +218,8 @@ public class DefaultRedisProvider implements RedisProvider {
     }
 
     private void doReconnect(int retry) {
-        long backoffMs = (long) (Math.pow(2, Math.min(retry, 10)) * configurationProvider.configuration().getRedisReconnectDelaySec());
+        long configDelayMs = configurationProvider.configuration().getRedisReconnectDelaySec() * 1000L;
+        long backoffMs = (long) (Math.pow(2, Math.min(retry, 10)) * configDelayMs);
         log.debug("Schedule reconnect #{} in {}ms.", retry, backoffMs);
         vertx.setTimer(backoffMs, timer -> connectToRedis().onFailure(ex -> {
             log.info("Reconnect failed. Try again.", ex);


### PR DESCRIPTION
Please review carefully, as I'm not sure what this code is supposed to do. From 1st intuition, it "*looks like a bug*". But I don't know if "*its a feature*". Could not find any doc yet which would clarify.

As my instance does not adjust this config value, I expect it to use the default. Which I assume is:
<img width="811" height="176" alt="image" src="https://github.com/user-attachments/assets/8123a198-d546-48df-9f48-4a947d98d27c" />

Contrary to my expectation I see:
<img width="830" height="207" alt="image" src="https://github.com/user-attachments/assets/8f9c93ab-fe8a-40b6-a56b-b3fd45b3c35d" />
