### PR TITLE
MSOP-7727 added expire function to per queue configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [4.1.42-SNAPSHOT] - 2026-06-22
+
+### New features
+- Add support config timeout
+  To enable this feature, you need set it via QueueConfiguration.configExpireTimeout. '0' means timeout disabled
+  the config will be removed after the timeout, if no update via setPerQueueConfiguration happened
+    - Example:
+```json
+{
+  "pattern":"listener-hook-http.*",
+  "retryIntervals":[10],
+  "configExpireTimeout": 10
+}
+```
+
 ## [4.1.41-SNAPSHOT] - 2026-05-21
 ### Major changes
 - From this version the Redis API version requirement change to > 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [4.1.42-SNAPSHOT] - 2026-06-22
+### Minor changes
+- added a flag named "batchQueue" into batch queue despatch message
 
 ### New features
 - Add support config timeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [4.1.42-SNAPSHOT] - 2026-06-22
 ### Minor changes
-- added a flag named "batchQueue" into batch queue despatch message
+- added a flag named "batchQueue" into the batch queue dispatch message
 
 ### New features
-- Add support config timeout
-  To enable this feature, you need set it via QueueConfiguration.configExpireTimeout. '0' means timeout disabled
+- Add support for per-queue config timeout
+  To enable this feature, you need to set it via QueueConfiguration.configExpireTimeout. '0' means timeout disabled
   the config will be removed after the timeout, if no update via setPerQueueConfiguration happened
     - Example:
 ```json

--- a/README.md
+++ b/README.md
@@ -708,8 +708,8 @@ Request Data
         "enqueueMaxDelayMillis": <max enqueue delay in millis (optional)>,
         "maximumItemInBatchDispatch": <Maximum queue items allowed in a batch request (optional).>,
         "minimumItemInBatchDispatch": <Minimum queue items required to do a batch (optional)>,
-        "maxBatchItemDispatchWaitTimeout": <How many seconds need to wait the queue items reach the minimum queue items required (optional)>,
-        "configExpireTimeout": <config live time in seconds, after timeout the config will removed (optional)>
+        "maxBatchItemDispatchWaitTimeout": <Maximum number of seconds to wait for the queue to reach the minimum required number of items before dispatching, even if the minimum is not reached (optional)>,
+        "configExpireTimeout": <config live time in seconds, after timeout the config will be removed (optional)>
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -708,7 +708,8 @@ Request Data
         "enqueueMaxDelayMillis": <max enqueue delay in millis (optional)>,
         "maximumItemInBatchDispatch": <Maximum queue items allowed in a batch request (optional).>,
         "minimumItemInBatchDispatch": <Minimum queue items required to do a batch (optional)>,
-        "maxBatchItemDispatchWaitTimeout": <How many seconds need to wait the queue items reach the minimum queue items required (optional)>
+        "maxBatchItemDispatchWaitTimeout": <How many seconds need to wait the queue items reach the minimum queue items required (optional)>,
+        "configExpireTimeout": <config live time in seconds, after timeout the config will removed (optional)>
     }
 }
 ```

--- a/src/main/java/org/swisspush/redisques/RedisQues.java
+++ b/src/main/java/org/swisspush/redisques/RedisQues.java
@@ -139,7 +139,8 @@ public class RedisQues extends AbstractVerticle {
                 if (this.dequeueStatisticCollector == null) {
                     this.dequeueStatisticCollector = new DequeueStatisticCollector(vertx, modConfig.isDequeueStatsEnabled(), redisService, keyspaceHelper);
                 }
-                QueueConfigurationProvider.provider(vertx, configurationProvider.configuration().getQueueConfigurations()).get().onComplete(event1 -> {
+                QueueConfigurationProvider.provider(vertx, configurationProvider.configuration().getQueueConfigurations(),
+                        configurationProvider.configuration().getQueueConfigCleanupInterval()).get().onComplete(event1 -> {
                     if (event1.succeeded()) {
                         RedisQues.this.queueConfigurationProvider = event1.result();
                         if (migrationToolDisabled) {

--- a/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
+++ b/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
@@ -324,14 +324,11 @@ public class QueueConsumerRunner {
                 }
                 Response response = answer.result();
                 log.trace("RedisQues read queue lrange item size: {}", response.size());
-
-                JsonObject batchItemsJsonObject = new  JsonObject();
                 JsonArray itemsJsonArray = new JsonArray();
                 for (Response res : response) {
                     itemsJsonArray.add(res.toString());
                 }
-                batchItemsJsonObject.put(PAYLOAD, itemsJsonArray);
-                processMessage(queueName, batchItemsJsonObject.toString(), maximumItemInBatchDispatch).onComplete(processMessageAnswer -> {
+                processMessage(queueName, itemsJsonArray.toString(), maximumItemInBatchDispatch).onComplete(processMessageAnswer -> {
                     if (processMessageAnswer.failed()) {
                         log.error("Failed to process queue '{}'", queueName, processMessageAnswer.cause());
                         promise.fail(processMessageAnswer.cause());

--- a/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
+++ b/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.lang.System.currentTimeMillis;
+import static org.swisspush.redisques.util.RedisquesAPI.BATCH_QUEUE;
 import static org.swisspush.redisques.util.RedisquesAPI.MESSAGE;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.PAYLOAD;
@@ -76,7 +77,7 @@ public class QueueConsumerRunner {
         this.queueConfigurationProvider = queueConfigurationProvider;
 
         // handles trim request
-        trimRequestConsumer = vertx.eventBus().consumer(keyspaceHelper.getTrimRequestKey(), event -> {
+        trimRequestConsumer = vertx.eventBus().consumer(keyspaceHelper.getTrimRequestKey() + keyspaceHelper.getVerticleUid(), event -> {
             final String queueName = event.body();
             if (queueName == null) {
                 log.warn("Got event bus trim request msg with empty body! uid={}  address={}  replyAddress={}", keyspaceHelper.getVerticleUid(), event.address(), event.replyAddress());
@@ -234,7 +235,7 @@ public class QueueConsumerRunner {
         String queueKey = keyspaceHelper.getQueuesPrefix() + queueName;
         queueStatsService.createDequeueStatisticIfMissing(queueName);
         queueStatsService.dequeueStatisticSetLastDequeueAttemptTimestamp(queueName, System.currentTimeMillis());
-        processMessageWithTimeout(queueName, message, processResult -> {
+        processMessageWithTimeout(queueName, message, messageSize > 1, processResult -> {
 
             // update the queue failure count and get a retry interval
             int retryInterval = updateQueueFailureCountAndGetRetryInterval(queueName, processResult.getKey());
@@ -323,11 +324,14 @@ public class QueueConsumerRunner {
                 }
                 Response response = answer.result();
                 log.trace("RedisQues read queue lrange item size: {}", response.size());
+
+                JsonObject batchItemsJsonObject = new  JsonObject();
                 JsonArray itemsJsonArray = new JsonArray();
                 for (Response res : response) {
                     itemsJsonArray.add(res.toString());
                 }
-                processMessage(queueName, itemsJsonArray.toString(), maximumItemInBatchDispatch).onComplete(processMessageAnswer -> {
+                batchItemsJsonObject.put(PAYLOAD, itemsJsonArray);
+                processMessage(queueName, batchItemsJsonObject.toString(), maximumItemInBatchDispatch).onComplete(processMessageAnswer -> {
                     if (processMessageAnswer.failed()) {
                         log.error("Failed to process queue '{}'", queueName, processMessageAnswer.cause());
                         promise.fail(processMessageAnswer.cause());
@@ -371,6 +375,7 @@ public class QueueConsumerRunner {
                                 if (delayed.failed()) {
                                     log.error("Delayed execution has failed.", exceptionFactory.newException(delayed.cause()));
                                 }
+                                setMyQueuesState(queueName, QueueState.READY);
                                 promise.complete();
                             });
                         }
@@ -459,7 +464,7 @@ public class QueueConsumerRunner {
         });
     }
 
-    private void processMessageWithTimeout(final String queue, final String payload, final Handler<Map.Entry<Boolean, String>> handler) {
+    private void processMessageWithTimeout(final String queue, final String payload, final boolean isBatch, final Handler<Map.Entry<Boolean, String>> handler) {
         long processorDelayMax = configurationProvider.configuration().getProcessorDelayMax();
         if (processorDelayMax > 0) {
             log.info("About to process message for queue {} with a maximum delay of {}ms", queue, processorDelayMax);
@@ -473,6 +478,9 @@ public class QueueConsumerRunner {
             String processorAddress = configurationProvider.configuration().getProcessorAddress();
             final EventBus eb = vertx.eventBus();
             JsonObject message = new JsonObject();
+            if (isBatch) {
+                message.put(BATCH_QUEUE, true);
+            }
             message.put("queue", queue);
             message.put(PAYLOAD, payload);
             log.trace("RedisQues process message: {} for queue: {} send it to processor: {}", message, queue, processorAddress);

--- a/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
@@ -69,6 +69,16 @@ public class QueueConfiguration {
      */
     private int maxBatchItemDispatchWaitTimeout = 0;
 
+    /**
+     * How many seconds this rule will alive, 0 means not enabled
+     */
+    private long configExpireTimeout = 0l;
+
+    /**
+     * When this configuration created or updated
+     */
+    private long lastRegisterTime = 0l;
+
     public QueueConfiguration(String pattern) {
         this.pattern = Pattern.compile(pattern);
     }
@@ -124,6 +134,15 @@ public class QueueConfiguration {
     public int getMaxBatchItemDispatchWaitTimeout() {
         return maxBatchItemDispatchWaitTimeout;
     }
+
+    public long getConfigExpireTimeout() {
+        return configExpireTimeout;
+    }
+
+    public long getLastRegisterTime() {
+        return lastRegisterTime;
+    }
+
 
     public JsonObject asJsonObject() {
         return JsonObject.mapFrom(this);
@@ -257,6 +276,34 @@ public class QueueConfiguration {
             throw new IllegalArgumentException("maxBatchItemDispatchWaitTimeout must be >=0 but is " + maxBatchItemDispatchWaitTimeout);
         }
         this.maxBatchItemDispatchWaitTimeout = maxBatchItemDispatchWaitTimeout;
+        return this;
+    }
+
+    /**
+     * set the max live time for queue configuration
+     *
+     * @param configExpireTimeout
+     * @return
+     */
+    public QueueConfiguration withConfigExpireTimeout(long configExpireTimeout) {
+        if (configExpireTimeout < 0) {
+            throw new IllegalArgumentException("configExpireTimeout must be >=0 but is " + configExpireTimeout);
+        }
+        this.configExpireTimeout = configExpireTimeout;
+        return this;
+    }
+
+    /**
+     * set the time this configuration created or updated
+     *
+     * @param lastRegisterTime
+     * @return
+     */
+    public QueueConfiguration withLastRegisterTime(long lastRegisterTime) {
+        if (lastRegisterTime < 0) {
+            throw new IllegalArgumentException("lastRegisterTime must be >=0 but is " + lastRegisterTime);
+        }
+        this.lastRegisterTime = lastRegisterTime;
         return this;
     }
 }

--- a/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfiguration.java
@@ -70,12 +70,12 @@ public class QueueConfiguration {
     private int maxBatchItemDispatchWaitTimeout = 0;
 
     /**
-     * How many seconds this rule will alive, 0 means not enabled
+     * How many seconds this rule will stay alive (effective), 0 means not enabled
      */
     private long configExpireTimeout = 0l;
 
     /**
-     * When this configuration created or updated
+     * When this configuration was created or updated
      */
     private long lastRegisterTime = 0l;
 
@@ -280,7 +280,7 @@ public class QueueConfiguration {
     }
 
     /**
-     * set the max live time for queue configuration
+     * set the max live time for this queue configuration
      *
      * @param configExpireTimeout
      * @return
@@ -294,7 +294,7 @@ public class QueueConfiguration {
     }
 
     /**
-     * set the time this configuration created or updated
+     * set the time this configuration was created or updated
      *
      * @param lastRegisterTime
      * @return

--- a/src/main/java/org/swisspush/redisques/util/QueueConfigurationProvider.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfigurationProvider.java
@@ -103,7 +103,9 @@ public class QueueConfigurationProvider {
                 if (DELETE.equals(operation)) {
                     final String configName = event.body().getString(RedisquesAPI.PER_QUEUE_CONFIG_NAME);
                     QueueConfiguration removedConfig = queueConfigurations.remove(configName);
-                    removeQueueConfigurationCategories(removedConfig);
+                    if (removedConfig != null) {
+                        removeQueueConfigurationCategories(removedConfig);
+                    }
                     log.debug("delete config {} from instance {}", configName, uid);
                 } else {
                     log.warn("Unsupported operation: {}", operation);

--- a/src/main/java/org/swisspush/redisques/util/QueueConfigurationProvider.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfigurationProvider.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 public class QueueConfigurationProvider {
     private static final Logger log = LoggerFactory.getLogger(QueueConfigurationProvider.class);
+    private static final long MIN_QUEUE_CONFIG_CLEANUP_INTERVAL = 1_000;
     public static final String DELETE = "DELETE";
 
     // Identify of the config provider, should be the same in the same vertx instance, but different in cluster node
@@ -70,7 +71,7 @@ public class QueueConfigurationProvider {
     }
 
 
-    private QueueConfigurationProvider(Vertx vertx, List<QueueConfiguration> defaultQueueConfigurations) {
+    private QueueConfigurationProvider(Vertx vertx, List<QueueConfiguration> defaultQueueConfigurations, long cleanupInterval) {
         this.vertx = vertx;
         this.defaultQueueConfigurations = defaultQueueConfigurations;
         loadStaticConfigs();
@@ -117,14 +118,14 @@ public class QueueConfigurationProvider {
         });
 
         // QueueConfiguration cleanup
-        vertx.setPeriodic(1_000, event -> queueConfigurationCleanUp());
+        vertx.setPeriodic(Math.max(MIN_QUEUE_CONFIG_CLEANUP_INTERVAL, cleanupInterval), event -> queueConfigurationCleanUp());
     }
 
-    public static NodeLocalSingletonProvider<QueueConfigurationProvider> provider(Vertx vertx, List<QueueConfiguration> defaultQueueConfigurations) {
+    public static NodeLocalSingletonProvider<QueueConfigurationProvider> provider(Vertx vertx, List<QueueConfiguration> defaultQueueConfigurations, long cleanupInterval) {
         return new NodeLocalSingletonProvider<>(
                 vertx,
                 "per-queue-config",
-                () -> Future.succeededFuture(new QueueConfigurationProvider(vertx, defaultQueueConfigurations)));
+                () -> Future.succeededFuture(new QueueConfigurationProvider(vertx, defaultQueueConfigurations, cleanupInterval)));
     }
 
     /**

--- a/src/main/java/org/swisspush/redisques/util/QueueConfigurationProvider.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueConfigurationProvider.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -114,6 +115,9 @@ public class QueueConfigurationProvider {
                 }
             }
         });
+
+        // QueueConfiguration cleanup
+        vertx.setPeriodic(1_000, event -> queueConfigurationCleanUp());
     }
 
     public static NodeLocalSingletonProvider<QueueConfigurationProvider> provider(Vertx vertx, List<QueueConfiguration> defaultQueueConfigurations) {
@@ -285,6 +289,11 @@ public class QueueConfigurationProvider {
             isNew = true;
         }
 
+        queueConfiguration.withLastRegisterTime(System.currentTimeMillis());
+
+        if (jsonObject.containsKey(RedisquesAPI.PER_QUEUE_CONFIG_EXPIRE_TIMEOUT)) {
+            queueConfiguration.withConfigExpireTimeout(jsonObject.getLong(RedisquesAPI.PER_QUEUE_CONFIG_EXPIRE_TIMEOUT));
+        }
         if (jsonObject.containsKey(RedisquesAPI.PER_QUEUE_CONFIG_MAXIMUM_ITEM_IN_BATCH_DISPATCH)) {
             queueConfiguration.withMaximumItemInBatchDispatch(jsonObject.getInteger(RedisquesAPI.PER_QUEUE_CONFIG_MAXIMUM_ITEM_IN_BATCH_DISPATCH));
         }
@@ -395,6 +404,21 @@ public class QueueConfigurationProvider {
                 queueConfigurations.put(queueConfiguration.getPattern(), queueConfiguration);
                 updateQueueConfigurationCategories(queueConfiguration);
             });
+        }
+    }
+
+    // remove expired queue configurations
+    private void queueConfigurationCleanUp() {
+        Iterator<Map.Entry<String, QueueConfiguration>> iterator = queueConfigurations.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, QueueConfiguration> entry = iterator.next();
+            if (entry.getValue().getConfigExpireTimeout() > 0) {
+                long expires = (entry.getValue().getConfigExpireTimeout() * 1000) + entry.getValue().getLastRegisterTime();
+                if (expires < System.currentTimeMillis()) {
+                    removeQueueConfigurationCategories(entry.getValue());
+                    iterator.remove();
+                }
+            }
         }
     }
 }

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -27,6 +27,7 @@ public class RedisquesAPI {
 
     public static final String MEMORY_FULL = "memory usage limit reached";
     public static final String QUEUE_PATROL_LIMITED = "patrol limit reached";
+    public static final String BATCH_QUEUE = "batchQueue";
     public static final String PAYLOAD = "payload";
     public static final String QUEUENAME = "queuename";
     public static final String FILTER = "filter";

--- a/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesAPI.java
@@ -58,6 +58,7 @@ public class RedisquesAPI {
     public static final String PER_QUEUE_CONFIG_MAXIMUM_ITEM_IN_BATCH_DISPATCH =  "maximumItemInBatchDispatch";
     public static final String PER_QUEUE_CONFIG_MINIMUM_ITEM_IN_BATCH_DISPATCH =  "minimumItemInBatchDispatch";
     public static final String PER_QUEUE_CONFIG_MAX_BATCH_DISPATCH_WAIT_TIMEOUT =  "maxBatchItemDispatchWaitTimeout";
+    public static final String PER_QUEUE_CONFIG_EXPIRE_TIMEOUT =  "configExpireTimeout";
     public static final String PER_QUEUE_CONFIG_NAME =  "configName";
     public static final String PER_QUEUE_CONFIG_PATTERN =  "pattern";
 

--- a/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
+++ b/src/main/java/org/swisspush/redisques/util/RedisquesConfiguration.java
@@ -74,6 +74,7 @@ public class RedisquesConfiguration {
     private final boolean tcpKeepAlive;
 
     private final RedisReplicas redisReplicasType;
+    private final long queueConfigCleanupInterval;
 
     private static final int DEFAULT_HTTP_REQUEST_HANDLER_MAX_HEADER_SIZE = 8192;
     private static final int DEFAULT_HTTP_REQUEST_HANDLER_MAX_INITIAL_LINE_LENGTH = 4096;
@@ -89,6 +90,7 @@ public class RedisquesConfiguration {
     private static final int DEFAULT_CONSUMER_LOCK_MULTIPLIER = 2;
     private static final int DEFAULT_EMPTY_QUEUE_LIVE_TIME_MS = -1;
     private static final RedisReplicas DEFAULT_REDIS_REPLICAS_TYPE = RedisReplicas.NEVER;
+    private static final long DEFAULT_QUEUE_CONFIG_CLEANUP_INTERVAL = 60_000;
 
     // We want to have more than the default of 24 max waiting requests and therefore
     // set the default here to infinity value. See as well:
@@ -165,6 +167,7 @@ public class RedisquesConfiguration {
     public static final String PROP_QUEUESITEMS_COUNT_REQUEST_QUOTA_ACQUIRE_RETRY_TIME_MS = "getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs";
     public static final String PROP_ACTIVE_QUEUE_REFRESH_REQUEST_QUOTA_ACQUIRE_RETRY_TIME_MS = "activeQueueRegRefreshReqQuotaAcquireRetryTimeMs";
     public static final String PROP_REDIS_CONNECTION_KEEP_ALIVE = "redisConnectionKeepAlive";
+    public static final String PROP_QUEUE_CONFIG_CLEANUP_INTERVAL = "queueConfigCleanupInterval";
 
     /**
      * Constructor with default values. Use the {@link RedisquesConfigurationBuilder} class
@@ -204,7 +207,7 @@ public class RedisquesConfiguration {
                 DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_REDIS_REPLICAS_TYPE, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC,
                 DEFAULT_REDIS_READY_CHECK_INTERVAL_MS, DEFAULT_EMPTY_QUEUE_LIVE_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
                 DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
-                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE);
+                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE, DEFAULT_QUEUE_CONFIG_CLEANUP_INTERVAL);
     }
 
     /**
@@ -235,7 +238,7 @@ public class RedisquesConfiguration {
                 DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_REDIS_REPLICAS_TYPE, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC,
                 DEFAULT_REDIS_READY_CHECK_INTERVAL_MS, DEFAULT_EMPTY_QUEUE_LIVE_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
                 DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
-                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE);
+                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE, DEFAULT_QUEUE_CONFIG_CLEANUP_INTERVAL);
     }
 
     /**
@@ -265,7 +268,7 @@ public class RedisquesConfiguration {
                 DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_REDIS_REPLICAS_TYPE, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC,
                 DEFAULT_REDIS_READY_CHECK_INTERVAL_MS, DEFAULT_EMPTY_QUEUE_LIVE_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
                 DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
-                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE);
+                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE, DEFAULT_QUEUE_CONFIG_CLEANUP_INTERVAL);
     }
 
     /**
@@ -295,7 +298,7 @@ public class RedisquesConfiguration {
                 DEFAULT_REDIS_POOL_RECYCLE_TIMEOUT_MS, DEFAULT_REDIS_REPLICAS_TYPE, DEFAULT_DEQUEUE_STATISTIC_REPORT_INTERVAL_SEC,
                 DEFAULT_REDIS_READY_CHECK_INTERVAL_MS, DEFAULT_EMPTY_QUEUE_LIVE_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
                 DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS, DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS,
-                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE);
+                DEFAULT_REDIS_CONNECTION_KEEP_ALIVE, DEFAULT_QUEUE_CONFIG_CLEANUP_INTERVAL);
     }
 
     private RedisquesConfiguration(String address, String configurationUpdatedAddress, String redisPrefix, String processorAddress,
@@ -317,7 +320,8 @@ public class RedisquesConfiguration {
                                    int dequeueStatisticReportIntervalSec, int redisReadyCheckIntervalMs, int emptyQueueLiveTimeMs,
                                    int redisMonitoringReqQuotaAcquireRetryTimeMs, int checkQueueRequestsQuotaAcquireRetryTimeMs,
                                    int queueStatsRequestQuotaAcquireRetryTimeMs, int getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs,
-                                   int activeQueueRegRefreshReqQuotaAcquireRetryTimeMs, boolean tcpKeepAlive) {
+                                   int activeQueueRegRefreshReqQuotaAcquireRetryTimeMs, boolean tcpKeepAlive,
+                                   long queueConfigCleanupInterval) {
         this.address = address;
         this.configurationUpdatedAddress = configurationUpdatedAddress;
         this.redisPrefix = redisPrefix;
@@ -343,6 +347,7 @@ public class RedisquesConfiguration {
         this.getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs = getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs;
         this.activeQueueRegRefreshReqQuotaAcquireRetryTimeMs = activeQueueRegRefreshReqQuotaAcquireRetryTimeMs;
         this.tcpKeepAlive = tcpKeepAlive;
+        this.queueConfigCleanupInterval = queueConfigCleanupInterval;
 
         Logger log = LoggerFactory.getLogger(RedisquesConfiguration.class);
 
@@ -479,7 +484,8 @@ public class RedisquesConfiguration {
                 builder.queueStatsRequestQuotaAcquireRetryTimeMs,
                 builder.getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs,
                 builder.activeQueueRegRefreshReqQuotaAcquireRetryTimeMs,
-                builder.tcpKeepAlive);
+                builder.tcpKeepAlive,
+                builder.queueConfigCleanupInterval);
     }
 
     public JsonObject asJsonObject() {
@@ -539,6 +545,7 @@ public class RedisquesConfiguration {
         obj.put(PROP_QUEUESITEMS_COUNT_REQUEST_QUOTA_ACQUIRE_RETRY_TIME_MS, getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs());
         obj.put(PROP_ACTIVE_QUEUE_REFRESH_REQUEST_QUOTA_ACQUIRE_RETRY_TIME_MS, getActiveQueueRegRefreshReqQuotaAcquireRetryTimeMs());
         obj.put(PROP_REDIS_CONNECTION_KEEP_ALIVE, getTcpKeepAlive());
+        obj.put(PROP_QUEUE_CONFIG_CLEANUP_INTERVAL, getQueueConfigCleanupInterval());
         return obj;
     }
 
@@ -711,6 +718,9 @@ public class RedisquesConfiguration {
         }
         if (json.containsKey(PROP_REDIS_CONNECTION_KEEP_ALIVE)) {
             builder.tcpKeepAlive(json.getBoolean(PROP_REDIS_CONNECTION_KEEP_ALIVE));
+        }
+        if (json.containsKey(PROP_QUEUE_CONFIG_CLEANUP_INTERVAL)) {
+            builder.queueConfigCleanupInterval(json.getLong(PROP_QUEUE_CONFIG_CLEANUP_INTERVAL));
         }
         return builder.build();
     }
@@ -968,6 +978,10 @@ public class RedisquesConfiguration {
         return redisReplicasType;
     }
 
+    public long getQueueConfigCleanupInterval() {
+        return queueConfigCleanupInterval;
+    }
+
     /**
      * RedisquesConfigurationBuilder class for simplified configuration.
      *
@@ -1035,6 +1049,7 @@ public class RedisquesConfiguration {
         private int getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs;
         private int activeQueueRegRefreshReqQuotaAcquireRetryTimeMs;
         private boolean tcpKeepAlive;
+        private long queueConfigCleanupInterval;
 
         public RedisquesConfigurationBuilder() {
             this.address = "redisques";
@@ -1084,6 +1099,7 @@ public class RedisquesConfiguration {
             this.getQueuesItemsCountRedisRequestQuotaAcquireRetryTimeMs = DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS;
             this.activeQueueRegRefreshReqQuotaAcquireRetryTimeMs = DEFAULT_QUOTA_ACQUIRE_RETRY_TIME_MS;
             this.tcpKeepAlive = false;
+            this.queueConfigCleanupInterval = DEFAULT_QUEUE_CONFIG_CLEANUP_INTERVAL;
         }
 
         public RedisquesConfigurationBuilder address(String address) {
@@ -1359,6 +1375,11 @@ public class RedisquesConfiguration {
 
         public RedisquesConfigurationBuilder tcpKeepAlive(boolean tcpKeepAlive) {
             this.tcpKeepAlive = tcpKeepAlive;
+            return this;
+        }
+
+        public RedisquesConfigurationBuilder queueConfigCleanupInterval(long queueConfigCleanupInterval) {
+            this.queueConfigCleanupInterval = queueConfigCleanupInterval;
             return this;
         }
 

--- a/src/test/java/org/swisspush/redisques/action/DeletePerQueueConfigurationsActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/DeletePerQueueConfigurationsActionTest.java
@@ -34,7 +34,7 @@ public class DeletePerQueueConfigurationsActionTest {
     public void testQueueConfigurationAction_deleteOneConfig(TestContext context) {
         final Async async = context.async();
         Message<JsonObject> message = Mockito.mock(Message.class);
-        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider queueConfigurationProvider = event.result();
             DeletePerQueueConfigurationsAction action = new DeletePerQueueConfigurationsAction(queueConfigurationProvider, Mockito.mock(Logger.class));
             queueConfigurationProvider.updateQueueConfiguration("test-pattern-1", createQueueConfiguration("test-pattern-1").asJsonObject());
@@ -59,7 +59,7 @@ public class DeletePerQueueConfigurationsActionTest {
     public void testQueueConfigurationAction_deleteNothing(TestContext context) {
         final Async async = context.async();
         Message<JsonObject> message = Mockito.mock(Message.class);
-        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider queueConfigurationProvider = event.result();
             DeletePerQueueConfigurationsAction action = new DeletePerQueueConfigurationsAction(queueConfigurationProvider, Mockito.mock(Logger.class));
             queueConfigurationProvider.updateQueueConfiguration("test-pattern-1", createQueueConfiguration("test-pattern-1").asJsonObject());

--- a/src/test/java/org/swisspush/redisques/action/GetPerQueueConfigurationsActionTest.java
+++ b/src/test/java/org/swisspush/redisques/action/GetPerQueueConfigurationsActionTest.java
@@ -38,7 +38,7 @@ public class GetPerQueueConfigurationsActionTest {
         Message<JsonObject> message = Mockito.mock(Message.class);
         ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
         when(message.body()).thenReturn(new JsonObject("{\"operation\":\"getPerQueueConfiguration\",\"payload\":{\"filter\":\"*\"}}"));
-        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider queueConfigurationProvider = event.result();
             GetPerQueueConfigurationsAction action = new GetPerQueueConfigurationsAction(queueConfigurationProvider, Mockito.mock(Logger.class));
 
@@ -64,7 +64,7 @@ public class GetPerQueueConfigurationsActionTest {
         Message<JsonObject> message = Mockito.mock(Message.class);
         ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
         when(message.body()).thenReturn(new JsonObject("{\"operation\":\"getPerQueueConfiguration\",\"payload\":{\"configName\":\"test-pattern-3\"}}"));
-        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(Vertx.vertx(), new ArrayList<>(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider queueConfigurationProvider = event.result();
             GetPerQueueConfigurationsAction action = new GetPerQueueConfigurationsAction(queueConfigurationProvider, Mockito.mock(Logger.class));
 

--- a/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
+++ b/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.swisspush.redisques.util.RedisquesAPI.BATCH_QUEUE;
 import static org.swisspush.redisques.util.RedisquesAPI.ERROR;
 import static org.swisspush.redisques.util.RedisquesAPI.OK;
 import static org.swisspush.redisques.util.RedisquesAPI.STATUS;
@@ -192,22 +193,26 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             log.info("Received '{}'", event.body());
             if (index.get() == 0) {
                 context.assertEquals("batch-queue-1.test", event.body().getString("queue"));
-                JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
-                context.assertEquals(3, itemsJsonArray.size());
+                context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                context.assertEquals(3, batchItemsJsonObject.size());
                 // the order is important
-                context.assertEquals("message_1-1", itemsJsonArray.getString(0));
-                context.assertEquals("message_1-2", itemsJsonArray.getString(1));
-                context.assertEquals("message_1-3", itemsJsonArray.getString(2));
+                context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
+                context.assertEquals("message_1-2", batchItemsJsonObject.getString(1));
+                context.assertEquals("message_1-3", batchItemsJsonObject.getString(2));
             } else if (index.get() == 1) {
                 context.assertEquals("batch-queue-4.test", event.body().getString("queue"));
-                JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
-                context.assertEquals(5, itemsJsonArray.size());
+                context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                context.assertEquals(5, batchItemsJsonObject.size());
                 // the order is important
-                context.assertEquals("message_4-1", itemsJsonArray.getString(0));
-                context.assertEquals("message_4-2", itemsJsonArray.getString(1));
-                context.assertEquals("message_4-3", itemsJsonArray.getString(2));
-                context.assertEquals("message_4-4", itemsJsonArray.getString(3));
-                context.assertEquals("message_4-5", itemsJsonArray.getString(4));
+                context.assertEquals("message_4-1", batchItemsJsonObject.getString(0));
+                context.assertEquals("message_4-2", batchItemsJsonObject.getString(1));
+                context.assertEquals("message_4-3", batchItemsJsonObject.getString(2));
+                context.assertEquals("message_4-4", batchItemsJsonObject.getString(3));
+                context.assertEquals("message_4-5", batchItemsJsonObject.getString(4));
             } else {
                 context.fail("unexpected index " + index);
             }
@@ -262,23 +267,25 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             public void handle(Message<JsonObject> event) {
                 log.info("Received '{}'", event.body());
                 if (index.get() == 0) {
-                    context.assertEquals("batch-queue-1.test", event.body().getString("queue"));
-                    JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
-                    context.assertEquals(3, itemsJsonArray.size());
+                    JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                    context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                    JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                    context.assertEquals(3, batchItemsJsonObject.size());
                     // the order is important
-                    context.assertEquals("message_1-1", itemsJsonArray.getString(0));
-                    context.assertEquals("message_1-2", itemsJsonArray.getString(1));
-                    context.assertEquals("message_1-3", itemsJsonArray.getString(2));
+                    context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
+                    context.assertEquals("message_1-2", batchItemsJsonObject.getString(1));
+                    context.assertEquals("message_1-3", batchItemsJsonObject.getString(2));
                 } else if (index.get() == 1) {
-                    context.assertEquals("batch-queue-4.test", event.body().getString("queue"));
-                    JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
-                    context.assertEquals(5, itemsJsonArray.size());
+                    JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                    context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                    JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                    context.assertEquals(5, batchItemsJsonObject.size());
                     // the order is important
-                    context.assertEquals("message_4-1", itemsJsonArray.getString(0));
-                    context.assertEquals("message_4-2", itemsJsonArray.getString(1));
-                    context.assertEquals("message_4-3", itemsJsonArray.getString(2));
-                    context.assertEquals("message_4-4", itemsJsonArray.getString(3));
-                    context.assertEquals("message_4-5", itemsJsonArray.getString(4));
+                    context.assertEquals("message_4-1", batchItemsJsonObject.getString(0));
+                    context.assertEquals("message_4-2", batchItemsJsonObject.getString(1));
+                    context.assertEquals("message_4-3", batchItemsJsonObject.getString(2));
+                    context.assertEquals("message_4-4", batchItemsJsonObject.getString(3));
+                    context.assertEquals("message_4-5", batchItemsJsonObject.getString(4));
                 } else {
                     context.fail("unexpected index " + index);
                 }
@@ -323,7 +330,6 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
         });
     }
 
-
     @Test
     public void testMultipleItemBatchDispatchSuccessWithMinimum(TestContext context) {
         Async async = context.async();
@@ -335,14 +341,15 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             if (index.get() == 0) {
                 context.fail("Should no dispatch");
             } else if (index.get() == 1) {
-                context.assertEquals(queueName, event.body().getString("queue"));
-                JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
-                context.assertEquals(4, itemsJsonArray.size());
+                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                context.assertEquals(4, batchItemsJsonObject.size());
                 // the order is important
-                context.assertEquals("message_1-1", itemsJsonArray.getString(0));
-                context.assertEquals("message_1-2", itemsJsonArray.getString(1));
-                context.assertEquals("message_1-3", itemsJsonArray.getString(2));
-                context.assertEquals("message_1-4", itemsJsonArray.getString(3));
+                context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
+                context.assertEquals("message_1-2", batchItemsJsonObject.getString(1));
+                context.assertEquals("message_1-3", batchItemsJsonObject.getString(2));
+                context.assertEquals("message_1-4", batchItemsJsonObject.getString(3));
             } else {
                 context.fail("unexpected index " + index);
             }
@@ -392,13 +399,14 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             } else if (index.get() == 2) {
                 context.fail("Should no dispatch");
             } else if (index.get() == 3) {
-                context.assertEquals(queueName, event.body().getString("queue"));
-                JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
-                context.assertEquals(3, itemsJsonArray.size());
+                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                context.assertEquals(3, batchItemsJsonObject.size());
                 // the order is important
-                context.assertEquals("message_1-1", itemsJsonArray.getString(0));
-                context.assertEquals("message_1-2", itemsJsonArray.getString(1));
-                context.assertEquals("message_1-3", itemsJsonArray.getString(2));
+                context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
+                context.assertEquals("message_1-2", batchItemsJsonObject.getString(1));
+                context.assertEquals("message_1-3", batchItemsJsonObject.getString(2));
             } else {
                 context.fail("unexpected index " + index);
             }
@@ -442,7 +450,6 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             });
         });
     }
-
 
     private Future<Void> addQueueItemsSequentially(List<String[]> items) {
         Promise<Void> promise = Promise.promise();

--- a/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
+++ b/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
@@ -194,8 +194,7 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             if (index.get() == 0) {
                 context.assertEquals("batch-queue-1.test", event.body().getString("queue"));
                 context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
-                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
-                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                 context.assertEquals(3, batchItemsJsonObject.size());
                 // the order is important
                 context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
@@ -204,8 +203,7 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             } else if (index.get() == 1) {
                 context.assertEquals("batch-queue-4.test", event.body().getString("queue"));
                 context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
-                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
-                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
+                JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                 context.assertEquals(5, batchItemsJsonObject.size());
                 // the order is important
                 context.assertEquals("message_4-1", batchItemsJsonObject.getString(0));
@@ -267,18 +265,16 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             public void handle(Message<JsonObject> event) {
                 log.info("Received '{}'", event.body());
                 if (index.get() == 0) {
-                    JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                    JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                     context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
-                    JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
                     context.assertEquals(3, batchItemsJsonObject.size());
                     // the order is important
                     context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
                     context.assertEquals("message_1-2", batchItemsJsonObject.getString(1));
                     context.assertEquals("message_1-3", batchItemsJsonObject.getString(2));
                 } else if (index.get() == 1) {
-                    JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                    JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                     context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
-                    JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
                     context.assertEquals(5, batchItemsJsonObject.size());
                     // the order is important
                     context.assertEquals("message_4-1", batchItemsJsonObject.getString(0));
@@ -341,9 +337,8 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             if (index.get() == 0) {
                 context.fail("Should no dispatch");
             } else if (index.get() == 1) {
-                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                 context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
-                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
                 context.assertEquals(4, batchItemsJsonObject.size());
                 // the order is important
                 context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));
@@ -399,9 +394,8 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             } else if (index.get() == 2) {
                 context.fail("Should no dispatch");
             } else if (index.get() == 3) {
-                JsonObject batchJsonObject = new JsonObject(event.body().getString("payload"));
+                JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                 context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
-                JsonArray batchItemsJsonObject = batchJsonObject.getJsonArray("payload");
                 context.assertEquals(3, batchItemsJsonObject.size());
                 // the order is important
                 context.assertEquals("message_1-1", batchItemsJsonObject.getString(0));

--- a/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
+++ b/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
@@ -74,6 +74,7 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
                         new QueueConfiguration("limited-queue-4.*")
                                 .withMaxQueueEntries(4))
                 )
+                .queueConfigCleanupInterval(1_000L)
                 .build()
                 .asJsonObject();
 

--- a/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
+++ b/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
@@ -194,7 +194,7 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
             log.info("Received '{}'", event.body());
             if (index.get() == 0) {
                 context.assertEquals("batch-queue-1.test", event.body().getString("queue"));
-                context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                context.assertTrue(event.body().getBoolean(BATCH_QUEUE));
                 JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                 context.assertEquals(3, batchItemsJsonObject.size());
                 // the order is important
@@ -203,7 +203,7 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
                 context.assertEquals("message_1-3", batchItemsJsonObject.getString(2));
             } else if (index.get() == 1) {
                 context.assertEquals("batch-queue-4.test", event.body().getString("queue"));
-                context.assertTrue(Boolean.parseBoolean(event.body().getString(BATCH_QUEUE)));
+                context.assertTrue(event.body().getBoolean(BATCH_QUEUE));
                 JsonArray batchItemsJsonObject = new JsonArray(event.body().getString("payload"));
                 context.assertEquals(5, batchItemsJsonObject.size());
                 // the order is important

--- a/src/test/java/org/swisspush/redisques/util/QueueConfigurationProviderTest.java
+++ b/src/test/java/org/swisspush/redisques/util/QueueConfigurationProviderTest.java
@@ -62,24 +62,24 @@ public class QueueConfigurationProviderTest {
             provider.updateQueueConfiguration("mytestqueue", jsonObject);
             QueueConfiguration queueConfiguration = provider.findQueueConfiguration("mytestqueue");
 
-            context.assertEquals(99,  queueConfiguration.getMaxQueueEntries());
-            context.assertEquals(11.0F,  queueConfiguration.getEnqueueDelayFactorMillis());
-            context.assertEquals(22,  queueConfiguration.getEnqueueMaxDelayMillis());
-            context.assertEquals(500,  queueConfiguration.getMaximumItemInBatchDispatch());
-            context.assertEquals(400,  queueConfiguration.getMinimumItemInBatchDispatch());
-            context.assertEquals(10,  queueConfiguration.getMaxBatchItemDispatchWaitTimeout());
-            context.assertEquals(3,  queueConfiguration.getRetryIntervals().length);
+            context.assertEquals(99, queueConfiguration.getMaxQueueEntries());
+            context.assertEquals(11.0F, queueConfiguration.getEnqueueDelayFactorMillis());
+            context.assertEquals(22, queueConfiguration.getEnqueueMaxDelayMillis());
+            context.assertEquals(500, queueConfiguration.getMaximumItemInBatchDispatch());
+            context.assertEquals(400, queueConfiguration.getMinimumItemInBatchDispatch());
+            context.assertEquals(10, queueConfiguration.getMaxBatchItemDispatchWaitTimeout());
+            context.assertEquals(3, queueConfiguration.getRetryIntervals().length);
 
             jsonObject.put(RedisquesAPI.PER_QUEUE_CONFIG_ENQUEUE_MAX_DELAY_MILLIS, 212);
             provider.updateQueueConfiguration("mytestqueue", jsonObject);
             QueueConfiguration queueConfigurationNew = provider.findQueueConfiguration("mytestqueue");
 
             // the object should be updated, not replaced
-            context.assertEquals(queueConfiguration,  queueConfigurationNew);
-            context.assertEquals(99,  queueConfiguration.getMaxQueueEntries());
-            context.assertEquals(11.0F,  queueConfiguration.getEnqueueDelayFactorMillis());
-            context.assertEquals(212,  queueConfiguration.getEnqueueMaxDelayMillis());
-            context.assertEquals(3,  queueConfiguration.getRetryIntervals().length);
+            context.assertEquals(queueConfiguration, queueConfigurationNew);
+            context.assertEquals(99, queueConfiguration.getMaxQueueEntries());
+            context.assertEquals(11.0F, queueConfiguration.getEnqueueDelayFactorMillis());
+            context.assertEquals(212, queueConfiguration.getEnqueueMaxDelayMillis());
+            context.assertEquals(3, queueConfiguration.getRetryIntervals().length);
             async.complete();
         });
     }
@@ -95,7 +95,7 @@ public class QueueConfigurationProviderTest {
             provider.updateQueueConfiguration("my_config_2", createQueueConfiguration("2.*").asJsonObject());
             provider.updateQueueConfiguration("my_config_3", createQueueConfiguration("3.*").asJsonObject());
             Map<String, QueueConfiguration> queueConfigurations = provider.getQueueConfigurations("*");
-            context.assertEquals(3,  queueConfigurations.size());
+            context.assertEquals(3, queueConfigurations.size());
             async.complete();
         });
     }
@@ -111,7 +111,7 @@ public class QueueConfigurationProviderTest {
             provider.updateQueueConfiguration("my_config_2", createQueueConfiguration("2.*").asJsonObject());
             provider.updateQueueConfiguration("my_config_3", createQueueConfiguration("3.*").asJsonObject());
             Map<String, QueueConfiguration> queueConfigurations = provider.getQueueConfigurations("my_config_2");
-            context.assertEquals(1,  queueConfigurations.size());
+            context.assertEquals(1, queueConfigurations.size());
             async.complete();
         });
     }
@@ -127,16 +127,16 @@ public class QueueConfigurationProviderTest {
             provider.updateQueueConfiguration("my_config_2", createQueueConfiguration("2.*").asJsonObject());
             provider.updateQueueConfiguration("my_config_3", createQueueConfiguration("3.*").asJsonObject());
             Map<String, QueueConfiguration> queueConfigurations = provider.getQueueConfigurations("*");
-            context.assertEquals(3,  queueConfigurations.size());
+            context.assertEquals(3, queueConfigurations.size());
             provider.removeQueueConfiguration("anything?");
-            context.assertEquals(3,  queueConfigurations.size());
+            context.assertEquals(3, queueConfigurations.size());
             provider.removeQueueConfiguration("my_config_1");
-            context.assertEquals(2,  queueConfigurations.size());
+            context.assertEquals(2, queueConfigurations.size());
             provider.removeQueueConfiguration("my_config_2");
             provider.removeQueueConfiguration("my_config_3");
-            context.assertEquals(0,  queueConfigurations.size());
+            context.assertEquals(0, queueConfigurations.size());
             provider.removeQueueConfiguration("my_config_3");
-            context.assertEquals(0,  queueConfigurations.size());
+            context.assertEquals(0, queueConfigurations.size());
             async.complete();
         });
     }
@@ -204,6 +204,52 @@ public class QueueConfigurationProviderTest {
             context.assertNull(provider.findBatchQueueItemsConfig("mytestqueue"));
 
             async.complete();
+        });
+    }
+
+    @Test
+    public void testQueueConfigExpiring(TestContext context) {
+        Async async = context.async();
+        Vertx vertx = Vertx.vertx();
+        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+            QueueConfigurationProvider provider = event.result();
+
+            provider.updateQueueConfiguration("my_config_1", createQueueConfiguration("1.*").asJsonObject());
+
+            QueueConfiguration expirableQueueConfiguration = createQueueConfiguration("2.*");
+            expirableQueueConfiguration.withConfigExpireTimeout(3);
+            provider.updateQueueConfiguration("my_config_2", expirableQueueConfiguration.asJsonObject());
+
+            provider.updateQueueConfiguration("my_config_3", createQueueConfiguration("3.*").asJsonObject());
+            Map<String, QueueConfiguration> queueConfigurations = provider.getQueueConfigurations("*");
+            context.assertEquals(3, queueConfigurations.size());
+            context.assertTrue(queueConfigurations.containsKey("my_config_1"));
+            context.assertTrue(queueConfigurations.containsKey("my_config_2"));
+            context.assertTrue(queueConfigurations.containsKey("my_config_3"));
+
+            vertx.setTimer(2000, event1 -> {
+                // try to update it
+                provider.updateQueueConfiguration("my_config_2", expirableQueueConfiguration.asJsonObject());
+
+                vertx.setTimer(2000, event2 -> {
+                    Map<String, QueueConfiguration> queueConfigurations1 = provider.getQueueConfigurations("*");
+                    // the "my_config_2" should still exist
+                    context.assertEquals(3, queueConfigurations1.size());
+                    context.assertTrue(queueConfigurations1.containsKey("my_config_1"));
+                    context.assertTrue(queueConfigurations1.containsKey("my_config_2"));
+                    context.assertTrue(queueConfigurations1.containsKey("my_config_3"));
+
+                    vertx.setTimer(2000, event3 -> {
+                        Map<String, QueueConfiguration> queueConfigurations2 = provider.getQueueConfigurations("*");
+                        // now "my_config_2" should have gone
+                        context.assertEquals(2, queueConfigurations2.size());
+                        context.assertTrue(queueConfigurations2.containsKey("my_config_1"));
+                        context.assertTrue(queueConfigurations2.containsKey("my_config_3"));
+                        async.complete();
+                    });
+                });
+            });
+
         });
     }
 

--- a/src/test/java/org/swisspush/redisques/util/QueueConfigurationProviderTest.java
+++ b/src/test/java/org/swisspush/redisques/util/QueueConfigurationProviderTest.java
@@ -25,10 +25,10 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigurationProviderCreation(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider1 = event.result();
             vertx.executeBlocking(promise -> {
-                QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event1 -> {
+                QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event1 -> {
                     context.assertEquals(provider1, event1.result());
                     context.assertEquals(provider1.getUid(), event1.result().getUid());
                     async.complete();
@@ -41,7 +41,7 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigUpdate(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider = event.result();
             context.assertNull(provider.findQueueConfiguration("mytestqueue"));
             JsonObject jsonObject = new JsonObject();
@@ -88,7 +88,7 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigGetAll(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider = event.result();
 
             provider.updateQueueConfiguration("my_config_1", createQueueConfiguration("1.*").asJsonObject());
@@ -104,7 +104,7 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigGetOne(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider = event.result();
 
             provider.updateQueueConfiguration("my_config_1", createQueueConfiguration("1.*").asJsonObject());
@@ -120,7 +120,7 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigRemove(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider = event.result();
 
             provider.updateQueueConfiguration("my_config_1", createQueueConfiguration("1.*").asJsonObject());
@@ -145,7 +145,7 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigCategoryRead(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider = event.result();
             context.assertNull(provider.findQueueConfiguration("mytestqueue"));
             JsonObject jsonObject = new JsonObject();
@@ -211,7 +211,7 @@ public class QueueConfigurationProviderTest {
     public void testQueueConfigExpiring(TestContext context) {
         Async async = context.async();
         Vertx vertx = Vertx.vertx();
-        QueueConfigurationProvider.provider(vertx, List.of()).get().onComplete(event -> {
+        QueueConfigurationProvider.provider(vertx, List.of(), 1_000).get().onComplete(event -> {
             QueueConfigurationProvider provider = event.result();
 
             provider.updateQueueConfiguration("my_config_1", createQueueConfiguration("1.*").asJsonObject());

--- a/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
+++ b/src/test/java/org/swisspush/redisques/util/RedisquesConfigurationTest.java
@@ -66,6 +66,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getActiveQueueRegRefreshReqQuotaAcquireRetryTimeMs(), -1);
         testContext.assertFalse(config.getTcpKeepAlive());
         testContext.assertEquals(config.getRedisReplicasType(), RedisReplicas.NEVER);
+        testContext.assertEquals(config.getQueueConfigCleanupInterval(), 60_000L);
     }
 
     @Test
@@ -110,6 +111,7 @@ public class RedisquesConfigurationTest {
                 .queueStatsRequestQuotaAcquireRetryTimeMs(5)
                 .tcpKeepAlive(true)
                 .redisReplicasType(RedisReplicas.ALWAYS)
+                .queueConfigCleanupInterval(10_000)
                 .build();
 
         // default values
@@ -157,6 +159,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getRedisReplicasType(), RedisReplicas.ALWAYS);
 
         // queue configurations
+        testContext.assertEquals(config.getQueueConfigCleanupInterval(), 10_000L);
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);
         QueueConfiguration queueConfiguration = config.getQueueConfigurations().get(0);
         testContext.assertEquals(queueConfiguration.getPattern(), "vehicle-.*");
@@ -211,6 +214,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(json.getInteger(PROP_QUEUE_STATS_REQUEST_QUOTA_ACQUIRE_RETRY_TIME_MS), -1);
         testContext.assertFalse(json.getBoolean(PROP_REDIS_CONNECTION_KEEP_ALIVE));
         testContext.assertEquals(RedisReplicas.valueOf(json.getString(PROP_REDIS_REPLICAS_TYPE)), RedisReplicas.NEVER);
+        testContext.assertEquals(json.getLong(PROP_QUEUE_CONFIG_CLEANUP_INTERVAL), 60_000L);
     }
 
     @Test
@@ -254,6 +258,7 @@ public class RedisquesConfigurationTest {
                 .queueStatsRequestQuotaAcquireRetryTimeMs(5)
                 .tcpKeepAlive(true)
                 .redisReplicasType(RedisReplicas.SHARE)
+                .queueConfigCleanupInterval(10_000)
                 .build();
 
         JsonObject json = config.asJsonObject();
@@ -305,6 +310,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(RedisReplicas.valueOf(json.getString(PROP_REDIS_REPLICAS_TYPE)), RedisReplicas.SHARE);
 
         // queue configurations
+        testContext.assertEquals(config.getQueueConfigCleanupInterval(), 10_000L);
         JsonArray queueConfigurationsJsonArray = json.getJsonArray(PROP_QUEUE_CONFIGURATIONS);
         List<JsonObject> queueConfigurationJsonObjects = queueConfigurationsJsonArray.getList();
         testContext.assertEquals(queueConfigurationJsonObjects.size(), 1);
@@ -361,6 +367,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getCheckQueueRequestsQuotaAcquireRetryTimeMs(), -1);
         testContext.assertFalse(config.getTcpKeepAlive());
         testContext.assertEquals(config.getRedisReplicasType(), RedisReplicas.NEVER);
+        testContext.assertEquals(config.getQueueConfigCleanupInterval(), 60_000L);
     }
 
     @Test
@@ -414,6 +421,7 @@ public class RedisquesConfigurationTest {
         json.put(PROP_QUEUE_STATS_REQUEST_QUOTA_ACQUIRE_RETRY_TIME_MS, 4);
         json.put(PROP_REDIS_CONNECTION_KEEP_ALIVE, true);
         json.put(PROP_REDIS_REPLICAS_TYPE, RedisReplicas.ALWAYS);
+        json.put(PROP_QUEUE_CONFIG_CLEANUP_INTERVAL, 20_000);
 
         RedisquesConfiguration config = fromJsonObject(json);
         testContext.assertEquals(config.getAddress(), "new_address");
@@ -459,6 +467,7 @@ public class RedisquesConfigurationTest {
         testContext.assertEquals(config.getRedisReplicasType(), RedisReplicas.ALWAYS);
 
         // queue configurations
+        testContext.assertEquals(config.getQueueConfigCleanupInterval(), 20_000L);
         testContext.assertEquals(config.getQueueConfigurations().size(), 1);
         QueueConfiguration queueConfiguration = config.getQueueConfigurations().get(0);
         testContext.assertEquals(queueConfiguration.getPattern(), "vehicle-.*");


### PR DESCRIPTION
Because will let service add queue configuration , so we also need the configuration gone after service shutdown
- added a flag to tell queue consumer message is a batched request
- moved duplicated payload