### PR TITLE
group batchQueue by uri and method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+
+## [4.1.46-SNAPSHOT] - 2026-07-15
+### Bugfixes
+- Fixed `QueueConsumerRunner#processMultipleItems` to ensure all queue items grouped
+  into a batch share the same `method` and `uri`. Previously, items with different
+  `method`/`uri` values could be dispatched together in the same batch. Now the batch
+  is closed as soon as an item with a different `method`/`uri` is encountered; that
+  item and any following items remain in the queue for the next dispatch cycle.
+- Fixed `QueueStatisticsCollector` to register the `QueueSizeInfoMapCodec` event bus
+  codec only once. Previously, creating multiple `QueueStatisticsCollector` instances
+  could trigger a duplicate codec registration error on the Vert.x event bus.
+
+
 ## [4.1.42-SNAPSHOT] - 2026-06-22
 ### Minor changes
 - added a flag named "batchQueue" into the batch queue dispatch message

--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,30 @@ depending on the batch dispatch configuration.
 
 ---
 
+#### Same `method` / `uri` grouping
+
+Batched queue items are expected to be dispatched to the same downstream endpoint.
+To guarantee this, the queue runner only groups consecutive queue items together
+when they share the **same `method` and `uri`**.
+
+Behavior:
+
+- the first queue item read from the queue defines the `method` / `uri` for the batch
+- subsequent queue items are appended to the batch only while their `method` and `uri`
+  match the first item
+- as soon as a queue item with a different `method` and/or `uri` is encountered,
+  the batch is closed (dispatched) without including that item
+- the differing item (and everything after it) remains in the queue and will be
+  picked up by the next dispatch cycle, potentially starting a new batch
+- queue items that cannot be parsed as JSON (i.e. no `method` / `uri` fields) are not
+  checked for consistency and are simply included in the batch
+
+This means a single call to the batch dispatch logic may send fewer items than
+`maximumItemInBatchDispatch`, even if more items are available in the queue, whenever
+a `method` / `uri` change is detected within the inspected range.
+
+---
+
 #### Important Difference Between `0` and `1` for `maximumItemInBatchDispatch`
 
 Although both configurations may result in processing one queue item at a time,

--- a/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
+++ b/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
@@ -346,10 +346,12 @@ public class QueueConsumerRunner {
                     String item = res.toString();
                     String itemMethod = null;
                     String itemUri = null;
+                    boolean itemParsed = false;
                     try {
                         JsonObject itemJson = new JsonObject(item);
                         itemMethod = itemJson.getString("method");
                         itemUri = itemJson.getString("uri");
+                        itemParsed = true;
                     } catch (Exception e) {
                         // item is not a JSON object (e.g. plain payload) - skip method/url consistency check for it
                         log.trace("RedisQues could not parse queue item of queue '{}' as json to check method/uri consistency", queueName);
@@ -358,7 +360,7 @@ public class QueueConsumerRunner {
                         // first item of the batch defines the method/url all following items must match
                         batchMethod = itemMethod;
                         batchUri = itemUri;
-                    } else if (itemMethod != null && itemUri != null
+                    } else if (itemParsed
                             && (!Objects.equals(itemMethod, batchMethod) || !Objects.equals(itemUri, batchUri))) {
                         // item has a different method/url than the current batch, stop growing the batch here so that
                         // only items with the same method and url are dispatched together

--- a/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
+++ b/src/main/java/org/swisspush/redisques/queue/QueueConsumerRunner.java
@@ -230,12 +230,12 @@ public class QueueConsumerRunner {
         return promise.future();
     }
 
-    private Future<Void> processMessage(String queueName, String message, int messageSize) {
+    private Future<Void> processMessage(String queueName, String message, int messageSize, final boolean batchQueue) {
         Promise<Void> promise = Promise.promise();
         String queueKey = keyspaceHelper.getQueuesPrefix() + queueName;
         queueStatsService.createDequeueStatisticIfMissing(queueName);
         queueStatsService.dequeueStatisticSetLastDequeueAttemptTimestamp(queueName, System.currentTimeMillis());
-        processMessageWithTimeout(queueName, message, messageSize > 1, processResult -> {
+        processMessageWithTimeout(queueName, message, batchQueue, processResult -> {
 
             // update the queue failure count and get a retry interval
             int retryInterval = updateQueueFailureCountAndGetRetryInterval(queueName, processResult.getKey());
@@ -259,7 +259,7 @@ public class QueueConsumerRunner {
                         log.trace("RedisQues read queue: {}", queueKey);
                         redisService.llen(queueKey).onComplete(answer1 -> {
                             if (answer1.succeeded() && answer1.result() != null) {
-                                if ( answer1.result().toLong() > 0L) {
+                                if (answer1.result().toLong() > 0L) {
                                     notifyConsumer(queueName).onComplete(event1 -> {
                                         if (event1.failed())
                                             log.warn("TODO error handling", exceptionFactory.newException(
@@ -339,10 +339,37 @@ public class QueueConsumerRunner {
                 Response response = answer.result();
                 log.trace("RedisQues read queue lrange item size: {}", response.size());
                 JsonArray itemsJsonArray = new JsonArray();
+                String batchMethod = null;
+                String batchUri = null;
+                int batchSize = 0;
                 for (Response res : response) {
-                    itemsJsonArray.add(res.toString());
+                    String item = res.toString();
+                    String itemMethod = null;
+                    String itemUri = null;
+                    try {
+                        JsonObject itemJson = new JsonObject(item);
+                        itemMethod = itemJson.getString("method");
+                        itemUri = itemJson.getString("uri");
+                    } catch (Exception e) {
+                        // item is not a JSON object (e.g. plain payload) - skip method/url consistency check for it
+                        log.trace("RedisQues could not parse queue item of queue '{}' as json to check method/uri consistency", queueName);
+                    }
+                    if (batchSize == 0) {
+                        // first item of the batch defines the method/url all following items must match
+                        batchMethod = itemMethod;
+                        batchUri = itemUri;
+                    } else if (itemMethod != null && itemUri != null
+                            && (!Objects.equals(itemMethod, batchMethod) || !Objects.equals(itemUri, batchUri))) {
+                        // item has a different method/url than the current batch, stop growing the batch here so that
+                        // only items with the same method and url are dispatched together
+                        log.debug("RedisQues stops batch dispatch for queue '{}' at item {} because method/uri differs from the batch ({} {} vs {} {})",
+                                queueName, batchSize, itemMethod, itemUri, batchMethod, batchUri);
+                        break;
+                    }
+                    itemsJsonArray.add(item);
+                    batchSize++;
                 }
-                processMessage(queueName, itemsJsonArray.toString(), maximumItemInBatchDispatch).onComplete(processMessageAnswer -> {
+                processMessage(queueName, itemsJsonArray.toString(), batchSize, true).onComplete(processMessageAnswer -> {
                     if (processMessageAnswer.failed()) {
                         log.error("Failed to process queue '{}'", queueName, processMessageAnswer.cause());
                         promise.fail(processMessageAnswer.cause());
@@ -419,7 +446,7 @@ public class QueueConsumerRunner {
             Response response = answer.result();
             log.trace("RedisQues read queue lindex result: {}", response);
             if (response != null) {
-                processMessage(queueName, response.toString(), 1).onComplete(processMessageAnswer -> {
+                processMessage(queueName, response.toString(), 1, false).onComplete(processMessageAnswer -> {
                     if (processMessageAnswer.failed()) {
                         log.error("Failed to process queue '{}'", queueName, processMessageAnswer.cause());
                         promise.fail(processMessageAnswer.cause());
@@ -475,7 +502,7 @@ public class QueueConsumerRunner {
         });
     }
 
-    private void processMessageWithTimeout(final String queue, final String payload, final boolean isBatch, final Handler<Map.Entry<Boolean, String>> handler) {
+    private void processMessageWithTimeout(final String queue, final String payload, final boolean batchQueue, final Handler<Map.Entry<Boolean, String>> handler) {
         long processorDelayMax = configurationProvider.configuration().getProcessorDelayMax();
         if (processorDelayMax > 0) {
             log.info("About to process message for queue {} with a maximum delay of {}ms", queue, processorDelayMax);
@@ -489,10 +516,10 @@ public class QueueConsumerRunner {
             String processorAddress = configurationProvider.configuration().getProcessorAddress();
             final EventBus eb = vertx.eventBus();
             JsonObject message = new JsonObject();
-            if (isBatch) {
-                message.put(BATCH_QUEUE, true);
-            }
             message.put("queue", queue);
+            if (batchQueue) {
+               message.put(BATCH_QUEUE, true);
+            }
             message.put(PAYLOAD, payload);
             log.trace("RedisQues process message: {} for queue: {} send it to processor: {}", message, queue, processorAddress);
 

--- a/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
+++ b/src/main/java/org/swisspush/redisques/util/QueueStatisticsCollector.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 
@@ -65,6 +66,7 @@ public class QueueStatisticsCollector {
     private static final Logger log = LoggerFactory.getLogger(QueueStatisticsCollector.class);
 
     private static final String STATSKEY = "redisques:stats";
+    public static final AtomicBoolean CODECS_REGISTERED = new AtomicBoolean(false);
     private final static String QUEUE_FAILURES = "failures";
     private final static String QUEUE_BACKPRESSURE = "backpressureTime";
     private final static String QUEUE_SLOWDOWNTIME = "slowdownTime";
@@ -86,6 +88,7 @@ public class QueueStatisticsCollector {
     private MessageConsumer<QueueSizeInfoMap> queueSizeConsumer;
     private Long speedStatisticsTimerId;
 
+
     public QueueStatisticsCollector(
             RedisService redisService,
             KeyspaceHelper keyspaceHelper,
@@ -103,7 +106,7 @@ public class QueueStatisticsCollector {
         this.configurationProvider = configurationProvider;
         this.keyspaceHelper = keyspaceHelper;
 
-        vertx.eventBus().registerDefaultCodec(QueueSizeInfoMap.class, new QueueSizeInfoMapCodec());
+        registerCodecs(vertx);
         speedStatisticsScheduler(speedIntervalSec);
         this.queueSizeConsumer = vertx.eventBus().consumer(keyspaceHelper.getQueueStatisticQueueSizeSyncKey(),
                 (Handler<Message<QueueSizeInfoMap>>) event ->
@@ -113,6 +116,12 @@ public class QueueStatisticsCollector {
                                 approximateQueueSize.put(key, value);
                             }
                         }));
+    }
+
+    public static void registerCodecs(Vertx vertx) {
+        if (CODECS_REGISTERED.compareAndSet(false, true)) {
+            vertx.eventBus().registerDefaultCodec(QueueSizeInfoMap.class, new QueueSizeInfoMapCodec());
+        }
     }
 
     /**

--- a/src/test/java/org/swisspush/redisques/RedisQuesTest.java
+++ b/src/test/java/org/swisspush/redisques/RedisQuesTest.java
@@ -49,6 +49,7 @@ public class RedisQuesTest extends AbstractTestCase {
 
     @After
     public void tearDown(TestContext context) {
+        QueueStatisticsCollector.CODECS_REGISTERED.set(false);
         vertx.close(context.asyncAssertSuccess());
     }
 

--- a/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
+++ b/src/test/java/org/swisspush/redisques/handler/RedisquesHttpRequestHandlerTest.java
@@ -25,6 +25,7 @@ import org.swisspush.redisques.RedisQues;
 import org.swisspush.redisques.util.DefaultRedisquesConfigurationProvider;
 import org.swisspush.redisques.util.QueueConfiguration;
 import org.swisspush.redisques.util.QueueConfigurationProvider;
+import org.swisspush.redisques.util.QueueStatisticsCollector;
 import org.swisspush.redisques.util.RedisquesAPI;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import org.swisspush.redisques.util.TestMemoryUsageProvider;
@@ -155,6 +156,7 @@ public class RedisquesHttpRequestHandlerTest extends AbstractTestCase {
 
     @Before
     public void deployRedisques(TestContext context) {
+        QueueStatisticsCollector.CODECS_REGISTERED.set(false);
         Async async = context.async();
         testVertx = Vertx.vertx();
         QueueConfigurationProvider.reset();

--- a/src/test/java/org/swisspush/redisques/metrics/MetricsCollectorTest.java
+++ b/src/test/java/org/swisspush/redisques/metrics/MetricsCollectorTest.java
@@ -48,7 +48,7 @@ public class MetricsCollectorTest extends AbstractTestCase {
     @Before
     public void deployRedisques(TestContext context) {
         vertx = Vertx.vertx();
-
+        QueueStatisticsCollector.CODECS_REGISTERED.set(false);
         JsonObject config = RedisquesConfiguration.with()
                 .processorAddress(PROCESSOR_ADDRESS)
                 .httpRequestHandlerEnabled(true)

--- a/src/test/java/org/swisspush/redisques/migration/MigrateToolTest.java
+++ b/src/test/java/org/swisspush/redisques/migration/MigrateToolTest.java
@@ -21,6 +21,7 @@ import org.swisspush.redisques.migration.tasks.Task;
 import org.swisspush.redisques.util.DefaultRedisquesConfigurationProvider;
 import org.swisspush.redisques.util.QueueConfiguration;
 import org.swisspush.redisques.util.QueueConfigurationProvider;
+import org.swisspush.redisques.util.QueueStatisticsCollector;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import org.swisspush.redisques.util.TestMemoryUsageProvider;
 import redis.clients.jedis.Jedis;
@@ -44,6 +45,7 @@ public class MigrateToolTest extends AbstractTestCase {
     @Before
     public void deployRedisques(TestContext context) {
         vertx = Vertx.vertx();
+        QueueStatisticsCollector.CODECS_REGISTERED.set(false);
         Async async = context.async();
         QueueConfigurationProvider.reset();
         RedisquesConfiguration rqConfig =  RedisquesConfiguration.with()

--- a/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
+++ b/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
@@ -463,6 +463,80 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
     }
 
     @Test
+    public void testMultipleItemBatchDispatchStopsWhenUriMissing(TestContext context) {
+        Async async = context.async();
+        final String queueName = "batch-queue-missing-uri.test";
+        final AtomicInteger index = new AtomicInteger(0);
+        final String getItem = new JsonObject().put("method", "GET").put("uri", "/foo").encode();
+        final String postItem = new JsonObject().put("method", "POST").put("uri", "/foo").encode();
+        final String postItemWithNoUri = new JsonObject().put("method", "POST").encode();
+        flushAll();
+        vertx.eventBus().consumer(RedisquesConfiguration.PROP_PROCESSOR_ADDRESS, (Handler<Message<JsonObject>>) event -> {
+            if (!Boolean.parseBoolean(event.body().getString("batchQueue"))) {
+                return;
+            }
+
+            context.assertEquals(queueName, event.body().getString("queue"));
+            JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
+            if (index.get() == 0) {
+                // 1st dispatch: leading 2 matching POST /foo items, stops before the GET item
+                context.assertEquals(2, itemsJsonArray.size());
+                context.assertEquals(postItem, itemsJsonArray.getString(0));
+                context.assertEquals(postItem, itemsJsonArray.getString(1));
+            } else if (index.get() == 1) {
+                // 2nd dispatch: the GET item alone, stops right away because the item without uri differs
+                context.assertEquals(1, itemsJsonArray.size());
+                context.assertEquals(getItem, itemsJsonArray.getString(0));
+            } else if (index.get() == 2) {
+                // 3rd dispatch: the item without uri alone, stops right away because the next item has a uri
+                context.assertEquals(1, itemsJsonArray.size());
+                context.assertEquals(postItemWithNoUri, itemsJsonArray.getString(0));
+            } else if (index.get() == 3) {
+                // 4th dispatch: the trailing POST /foo item dispatched alone
+                context.assertEquals(1, itemsJsonArray.size());
+                context.assertEquals(postItem, itemsJsonArray.getString(0));
+            } else {
+                context.fail("unexpected index " + index);
+            }
+            event.reply(new JsonObject().put(STATUS, OK));
+        });
+
+        List<String[]> items = List.of(
+                new String[]{queueName, postItem},
+                new String[]{queueName, postItem},
+                new String[]{queueName, getItem},
+                new String[]{queueName, postItemWithNoUri},
+                new String[]{queueName, postItem}
+        );
+
+        addQueueItemsSequentially(items).onComplete(e11 -> {
+            assertQueuesCount(context, 1);
+            assertQueueItemsCount(context, queueName, 5);
+            redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event1 -> {
+                // the batch stopped after the leading 2 matching items because the 3rd item's method differs
+                assertQueueItemsCount(context, queueName, 3);
+                index.incrementAndGet();
+                redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event2 -> {
+                    // the GET item was dispatched alone since the item without uri differs from it
+                    assertQueueItemsCount(context, queueName, 2);
+                    index.incrementAndGet();
+                    redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event3 -> {
+                        // the item without uri was dispatched alone since it differs from the following POST /foo item
+                        assertQueueItemsCount(context, queueName, 1);
+                        index.incrementAndGet();
+                        redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event4 -> {
+                            // the trailing item is dispatched on its own
+                            assertQueuesCount(context, 0);
+                            assertQueueItemsCount(context, queueName, 0);
+                            async.complete();
+                        });
+                    });
+                });
+            });
+        });
+    }
+
+    @Test
     public void testMultipleItemBatchDispatchSuccessWithMinimum(TestContext context) {
         Async async = context.async();
         final AtomicInteger index = new AtomicInteger(0);

--- a/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
+++ b/src/test/java/org/swisspush/redisques/queue/QueueConsumerRunnerTest.java
@@ -24,6 +24,7 @@ import org.swisspush.redisques.RedisQues;
 import org.swisspush.redisques.util.DefaultRedisquesConfigurationProvider;
 import org.swisspush.redisques.util.QueueConfiguration;
 import org.swisspush.redisques.util.QueueConfigurationProvider;
+import org.swisspush.redisques.util.QueueStatisticsCollector;
 import org.swisspush.redisques.util.RedisquesConfiguration;
 import org.swisspush.redisques.util.TestMemoryUsageProvider;
 import redis.clients.jedis.Jedis;
@@ -56,6 +57,7 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
     public void deployRedisques(TestContext context) {
         vertx = Vertx.vertx();
         QueueConfigurationProvider.reset();
+        QueueStatisticsCollector.CODECS_REGISTERED.set(false);
         JsonObject config = RedisquesConfiguration.with()
                 .processorAddress(PROCESSOR_ADDRESS)
                 .micrometerMetricsEnabled(true)
@@ -323,6 +325,139 @@ public class QueueConsumerRunnerTest extends AbstractTestCase {
                         }
                     });
                 }
+            });
+        });
+    }
+
+    @Test
+    public void testMultipleItemBatchDispatchStopsWhenMethodDiffers(TestContext context) {
+        Async async = context.async();
+        final String queueName = "batch-queue-method.test";
+        final AtomicInteger index = new AtomicInteger(0);
+        final String postItem = new JsonObject().put("method", "POST").put("uri", "/foo").encode();
+        final String getItem = new JsonObject().put("method", "GET").put("uri", "/foo").encode();
+        flushAll();
+        vertx.eventBus().consumer(RedisquesConfiguration.PROP_PROCESSOR_ADDRESS, (Handler<Message<JsonObject>>) event -> {
+            if (!Boolean.parseBoolean(event.body().getString("batchQueue"))) {
+                return;
+            }
+
+            context.assertEquals(queueName, event.body().getString("queue"));
+            JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
+            if (index.get() == 0) {
+                // 1st dispatch: leading 2 matching POST items, stops before the GET item
+                context.assertEquals(2, itemsJsonArray.size());
+                context.assertEquals(postItem, itemsJsonArray.getString(0));
+                context.assertEquals(postItem, itemsJsonArray.getString(1));
+            } else if (index.get() == 1) {
+                // 2nd dispatch: the GET item alone, stops right away because the next item is POST
+                context.assertEquals(1, itemsJsonArray.size());
+                context.assertEquals(getItem, itemsJsonArray.getString(0));
+            } else if (index.get() == 2) {
+                // 3rd dispatch: remaining 2 POST items all match, dispatched together
+                context.assertEquals(2, itemsJsonArray.size());
+                context.assertEquals(postItem, itemsJsonArray.getString(0));
+                context.assertEquals(postItem, itemsJsonArray.getString(1));
+            } else {
+                context.fail("unexpected index " + index);
+            }
+            event.reply(new JsonObject().put(STATUS, OK));
+        });
+
+        List<String[]> items = List.of(
+                new String[]{queueName, postItem},
+                new String[]{queueName, postItem},
+                new String[]{queueName, getItem},
+                new String[]{queueName, postItem},
+                new String[]{queueName, postItem}
+        );
+
+        addQueueItemsSequentially(items).onComplete(e11 -> {
+            assertQueuesCount(context, 1);
+            assertQueueItemsCount(context, queueName, 5);
+            redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event1 -> {
+                // the batch stopped after the leading 2 matching items because the 3rd item's method differs
+                assertQueueItemsCount(context, queueName, 3);
+                index.incrementAndGet();
+                redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event2 -> {
+                    // the GET item was dispatched alone since it differs from the following POST items
+                    assertQueueItemsCount(context, queueName, 2);
+                    index.incrementAndGet();
+                    redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event3 -> {
+                        // all remaining items share the same method/uri, so they are dispatched together
+                        assertQueuesCount(context, 0);
+                        assertQueueItemsCount(context, queueName, 0);
+                        async.complete();
+                    });
+                });
+            });
+        });
+    }
+
+    @Test
+    public void testMultipleItemBatchDispatchStopsWhenUriDiffers(TestContext context) {
+        Async async = context.async();
+        final String queueName = "batch-queue-uri.test";
+        final AtomicInteger index = new AtomicInteger(0);
+        final String fooItem = new JsonObject().put("method", "POST").put("uri", "/foo").encode();
+        final String barItem = new JsonObject().put("method", "POST").put("uri", "/bar").encode();
+        flushAll();
+        vertx.eventBus().consumer(RedisquesConfiguration.PROP_PROCESSOR_ADDRESS, (Handler<Message<JsonObject>>) event -> {
+            if (!Boolean.parseBoolean(event.body().getString("batchQueue"))) {
+                return;
+            }
+
+            context.assertEquals(queueName, event.body().getString("queue"));
+            JsonArray itemsJsonArray = new JsonArray(event.body().getString("payload"));
+            if (index.get() == 0) {
+                // 1st dispatch: leading 2 matching "/foo" items, stops before the "/bar" item
+                context.assertEquals(2, itemsJsonArray.size());
+                context.assertEquals(fooItem, itemsJsonArray.getString(0));
+                context.assertEquals(fooItem, itemsJsonArray.getString(1));
+            } else if (index.get() == 1) {
+                // 2nd dispatch: the "/bar" item alone, stops right away because the next item is "/foo"
+                context.assertEquals(1, itemsJsonArray.size());
+                context.assertEquals(barItem, itemsJsonArray.getString(0));
+            } else if (index.get() == 2) {
+                // 3rd dispatch: remaining 3 "/foo" items all match, dispatched together
+                context.assertEquals(3, itemsJsonArray.size());
+                context.assertEquals(fooItem, itemsJsonArray.getString(0));
+                context.assertEquals(fooItem, itemsJsonArray.getString(1));
+                context.assertEquals(fooItem, itemsJsonArray.getString(2));
+            } else {
+                context.fail("unexpected index " + index);
+            }
+            event.reply(new JsonObject().put(STATUS, OK));
+        });
+
+        List<String[]> items = List.of(
+                new String[]{queueName, fooItem},
+                new String[]{queueName, fooItem},
+                new String[]{queueName, barItem},
+                new String[]{queueName, fooItem},
+                new String[]{queueName, fooItem},
+                new String[]{queueName, fooItem}
+        );
+
+        addQueueItemsSequentially(items).onComplete(e11 -> {
+            assertQueuesCount(context, 1);
+            assertQueueItemsCount(context, queueName, 6);
+            redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event1 -> {
+                // the batch stopped after the leading 2 matching items because the 3rd item's uri differs
+                // (lrange only inspected the first 5 items, capped by maximumItemInBatchDispatch)
+                assertQueueItemsCount(context, queueName, 4);
+                index.incrementAndGet();
+                redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event2 -> {
+                    // the "/bar" item was dispatched alone since it differs from the following "/foo" items
+                    assertQueueItemsCount(context, queueName, 3);
+                    index.incrementAndGet();
+                    redisQues.getQueueConsumerRunner().processMultipleItems(queueName, 5, 0, 0).onComplete(event3 -> {
+                        // all remaining items share the same method/uri, so they are dispatched together
+                        assertQueuesCount(context, 0);
+                        assertQueueItemsCount(context, queueName, 0);
+                        async.complete();
+                    });
+                });
             });
         });
     }

--- a/src/test/java/org/swisspush/redisques/util/QueueStatisticsCollectorTest.java
+++ b/src/test/java/org/swisspush/redisques/util/QueueStatisticsCollectorTest.java
@@ -49,7 +49,7 @@ public class QueueStatisticsCollectorTest {
         this.configurationProvider = Mockito.mock(RedisquesConfigurationProvider.class);
 
         when(keyspaceHelper.getQueueStatisticQueueSizeSyncKey()).thenReturn("sync_key");
-
+        QueueStatisticsCollector.CODECS_REGISTERED.set(false);
         queueStatisticsCollector = new QueueStatisticsCollector(redisService, keyspaceHelper, vertx,
                 exceptionFactory, redisRequestQuota, 10, configurationProvider);
     }


### PR DESCRIPTION
I found no way to fix this in Gateleen, so I fixed it in here

To ensure all queue items grouped into a batch share the same `method` and `uri`. Previously, items with different `method`/`uri` values could be dispatched together in the same batch. Now the batch is closed as soon as an item with a different `method`/`uri` is encountered; that  item and any following items remain in the queue for the next dispatch cycle.